### PR TITLE
Remove redundant ruby-version parameter from CI actions setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,6 @@ jobs:
       uses: cloud-officer/ci-actions/setup@v2
       if: "${{needs.variables.outputs.SKIP_LICENSES != '1' || needs.variables.outputs.SKIP_TESTS != '1'}}"
       with:
-        ruby-version: "${{env.RUBY-VERSION}}"
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
         xcode-version: "${{env.XCODE-VERSION}}"
         github-token: "${{secrets.GH_PAT}}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -21,7 +21,6 @@ jobs:
       id: setup
       uses: cloud-officer/ci-actions/setup@v2
       with:
-        ruby-version: "${{env.RUBY-VERSION}}"
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
         xcode-version: "${{env.XCODE-VERSION}}"
         github-token: "${{secrets.GH_PAT}}"


### PR DESCRIPTION
# Summary

This PR removes the `ruby-version` parameter from the CI actions setup steps in the workflow files. Following the recent move of the Ruby version to a `.ruby-version` file (#235), the ci-actions/setup action now reads the Ruby version directly from that file, making the explicit parameter redundant.

**Key changes:**
- Remove `ruby-version` parameter from `build.yml` setup step
- Remove `ruby-version` parameter from `dependencies.yml` setup step

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: No code logic changes, only CI configuration cleanup
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
