### PR TITLE
Fix #247: Add startup validation for configuration files

### DIFF
--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -32,6 +32,7 @@ module SOUP
     end
 
     def execute
+      validate_config!
       detect_packages
       read_cached_packages
       check_packages
@@ -40,6 +41,18 @@ module SOUP
     end
 
     private
+
+    def validate_config!
+      [@options.licenses_file, @options.exceptions_file].each do |file|
+        raise("Configuration file not found: #{file}") unless File.exist?(file)
+
+        begin
+          JSON.parse(File.read(file))
+        rescue JSON::ParserError => e
+          raise("Invalid JSON in configuration file #{file}: #{e.message}")
+        end
+      end
+    end
 
     def markdown_cell(value)
       return ' ' if value.nil? || value.to_s.strip.empty?


### PR DESCRIPTION
# Summary

Add startup validation for configuration files (`licenses.json`, `exceptions.json`) to fail fast on missing or invalid config rather than failing mid-execution. A new `validate_config!` method is called at the start of `execute` in `Application`, before any package scanning begins.

**Key changes:**

- Add `validate_config!` private method to `Application` that validates both `licenses_file` and `exceptions_file` exist and contain valid JSON
- Call `validate_config!` at the start of `execute` to fail fast before `detect_packages` runs

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified