### PR TITLE
Fix #249: Extract parser registry, HTTP client, and string sanitization

### DIFF
--- a/lib/soup.rb
+++ b/lib/soup.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 module SOUP
-  PACKAGE_MANAGERS = %w[buildscript-gradle.lockfile composer.lock Gemfile.lock Package.resolved package-lock.json Podfile.lock requirements.txt yarn.lock].freeze
   RISK_LEVELS_SCREEN =
     [
-      'Low (can’t lead to harm)',
+      "Low (can\u2019t lead to harm)",
       'Medium (can lead to reversible harm)',
       'High (can lead to irreversible harm)'
     ].freeze
 
-  private_constant :PACKAGE_MANAGERS
   private_constant :RISK_LEVELS_SCREEN
 end

--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -6,6 +6,7 @@ require 'nokogiri'
 require 'tty-prompt'
 
 require_relative '../soup'
+require_relative 'http_client'
 require_relative 'options'
 require_relative 'parsers/bundler'
 # require_relative 'parsers/cocoapods'
@@ -21,6 +22,18 @@ require_relative 'status'
 DEPENDENCY_TEXT = 'Dependency'
 
 module SOUP
+  PARSER_REGISTRY = {
+    'buildscript-gradle.lockfile': { parser: GradleParser, skip: :skip_gradle },
+    'composer.lock': { parser: ComposerParser, skip: :skip_composer },
+    'Gemfile.lock': { parser: BundlerParser, skip: :skip_bundler },
+    'Package.resolved': { parser: SPMParser, skip: :skip_spm },
+    'package-lock.json': { parser: NPMParser, skip: :skip_npm },
+    'Podfile.lock': { parser: nil, skip: :skip_cocoapods }, # Disabled: cocoapods-core requires activesupport < 8
+    'requirements.txt': { parser: PIPParser, skip: :skip_pip },
+    'yarn.lock': { parser: YarnParser, skip: :skip_yarn }
+  }.freeze
+
+  private_constant :PARSER_REGISTRY
   # Represents an instance of a soup application. This is the entry point for all invocations of soup from the command line.
   class Application
     def initialize(argv)
@@ -71,9 +84,9 @@ module SOUP
     end
 
     def detect_packages
-      parser = GenericParser.new
+      generic_parser = GenericParser.new
 
-      PACKAGE_MANAGERS.each do |package_file|
+      PARSER_REGISTRY.each do |package_file, config|
         Dir.glob("#{Dir.pwd}/**/#{package_file}").each do |file|
           next if file.include?('/node_modules/')
 
@@ -85,53 +98,10 @@ module SOUP
           end
 
           puts("Reading file #{file}...")
+          next if @options.public_send(config[:skip])
+          next if config[:parser].nil?
 
-          case File.basename(file)
-          when 'buildscript-gradle.lockfile'
-            next if @options.skip_gradle
-
-            parser.parse(GradleParser.new, file, @detected_packages)
-
-          when 'composer.lock'
-            next if @options.skip_composer
-
-            parser.parse(ComposerParser.new, file, @detected_packages)
-
-          when 'Gemfile.lock'
-            next if @options.skip_bundler
-
-            parser.parse(BundlerParser.new, file, @detected_packages)
-
-          when 'Package.resolved'
-            next if @options.skip_spm
-
-            parser.parse(SPMParser.new, file, @detected_packages)
-
-          when 'package-lock.json'
-            next if @options.skip_npm
-
-            parser.parse(NPMParser.new, file, @detected_packages)
-
-          when 'Podfile.lock'
-            next if @options.skip_cocoapods
-
-            next unless RUBY_PLATFORM.match?(/darwin/i)
-
-            # parser.parse(CocoaPodsParser.new, file, @detected_packages)
-
-          when 'requirements.txt'
-            next if @options.skip_pip
-
-            parser.parse(PIPParser.new, file, @detected_packages)
-
-          when 'yarn.lock'
-            next if @options.skip_yarn
-
-            parser.parse(YarnParser.new, file, @detected_packages)
-
-          else
-            raise("Unknown file #{File.basename(file)}!")
-          end
+          generic_parser.parse(config[:parser].new, file, @detected_packages)
         end
       end
     end

--- a/lib/soup/http_client.rb
+++ b/lib/soup/http_client.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'httparty'
+
+module SOUP
+  module HttpClient
+    MAX_RETRIES = 3
+    DEFAULT_TIMEOUT = 5
+
+    private_constant :MAX_RETRIES
+    private_constant :DEFAULT_TIMEOUT
+
+    def self.get(url, max_retries: MAX_RETRIES, **options)
+      retries = 0
+
+      begin
+        HTTParty.get(url, { timeout: DEFAULT_TIMEOUT }.merge(options))
+      rescue Net::OpenTimeout, Net::ReadTimeout => e
+        retries += 1
+
+        if retries <= max_retries
+          puts("Error: #{e.message}. Retrying (#{retries}/#{max_retries})...")
+          retry
+        end
+
+        puts("Error: #{e.message}. Aborting after #{max_retries} retries.")
+        raise
+      end
+    end
+  end
+end

--- a/lib/soup/package.rb
+++ b/lib/soup/package.rb
@@ -2,6 +2,15 @@
 
 module SOUP
   class Package
+    def self.sanitize_description(text, first_sentence: false, strip_markdown: false)
+      return if text.nil?
+
+      text = text.split(/\n|\. /).first if first_sentence
+      text = text.gsub(%r{((?:f|ht)tps?:/\S+)}, '<\1>')
+      text = text.delete('_[]!|') if strip_markdown
+      text
+    end
+
     def initialize(package)
       raise('No package specified!') if package.nil?
 

--- a/lib/soup/parsers/bundler.rb
+++ b/lib/soup/parsers/bundler.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'bundler'
-require 'httparty'
 require 'json'
 
 require_relative '../package'
@@ -14,15 +13,15 @@ module SOUP
 
       lock_file.specs.each do |spec|
         puts("Checking #{spec.name} #{spec.version}...")
-        response = HTTParty.get("https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{spec.version}.json")
+        response = HttpClient.get("https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{spec.version}.json")
 
         if response.code != 200
-          response = HTTParty.get("https://api.rubygems.org/api/v1/versions/#{spec.name}/latest.json")
+          response = HttpClient.get("https://api.rubygems.org/api/v1/versions/#{spec.name}/latest.json")
 
           raise(response.message) unless response.code == 200
 
           latest_version = JSON.parse(response.body)['version']
-          response = HTTParty.get("https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{latest_version}.json")
+          response = HttpClient.get("https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{latest_version}.json")
 
           raise(response.message) unless response.code == 200
         end
@@ -33,8 +32,7 @@ module SOUP
         package.language = 'Ruby'
         package.version = spec.version&.to_s&.strip
         package.license = package_details['licenses']&.first&.strip
-        package_info = package_details['info']&.split(/\n|\. /)&.first
-        package.description = package_info&.gsub(%r{((?:f|ht)tps?:/\S+)}, '<\1>')
+        package.description = Package.sanitize_description(package_details['info'], first_sentence: true)
         package.website = package_details['homepage_uri']&.strip
         package.dependency = !main_file.include?(package.package)
         packages[package.package] = package

--- a/lib/soup/parsers/composer.rb
+++ b/lib/soup/parsers/composer.rb
@@ -23,8 +23,7 @@ module SOUP
         license = license&.split&.first
         package.license = license
         package.license = 'NOASSERTION' if package.license&.start_with?('http')
-        description = php_package['description']&.split(/\n|\. /)&.first
-        package.description = description&.gsub(%r{((?:f|ht)tps?:/\S+)}, '<\1>')
+        package.description = Package.sanitize_description(php_package['description'], first_sentence: true)
         package.website = php_package['homepage']&.strip
         package.dependency = !main_file.include?(package.package)
         packages[package.package] = package

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -22,7 +22,7 @@ module SOUP
 
         group_id, artifact_id, version = package_name.split(':')
         puts("Checking #{group_id}:#{artifact_id} #{version}...")
-        response = HTTParty.get("https://search.maven.org/solrsearch/select?q=g:%22#{group_id}%22+AND+a:%22#{artifact_id}%22+AND+v:%22#{version}%22&rows=1&wt=json")
+        response = HttpClient.get("https://search.maven.org/solrsearch/select?q=g:%22#{group_id}%22+AND+a:%22#{artifact_id}%22+AND+v:%22#{version}%22&rows=1&wt=json")
 
         if response.code == 200 and JSON.parse(response.body)['response']['numFound'] == 1
           package_details = JSON.parse(response.body)['response']['docs'][0]
@@ -31,7 +31,7 @@ module SOUP
           website = package_details['home_page']
         else
           REPOSITORY_URLS.each do |url|
-            response = HTTParty.get("#{url}/#{group_id.tr('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom")
+            response = HttpClient.get("#{url}/#{group_id.tr('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom")
 
             next unless response.code == 200
 

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -4,9 +4,6 @@ require_relative '../package'
 
 module SOUP
   class NPMParser
-    MAX_RETRIES = 3
-    private_constant :MAX_RETRIES
-
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
       main_file = File.read(file.gsub('package-lock.json', 'package.json'))
@@ -19,21 +16,11 @@ module SOUP
 
         name = key.split('node_modules/').last
         puts("Checking #{name} #{value['version']}...")
-        response = nil
-        retries = 0
 
         begin
-          response = HTTParty.get("https://registry.npmjs.org/#{name}")
-        rescue Net::OpenTimeout => e
-          retries += 1
-
-          if retries <= MAX_RETRIES
-            puts("Error: #{e.message}. Retrying (#{retries}/#{MAX_RETRIES})...")
-            retry
-          else
-            puts("Error: #{e.message}. Aborting after #{MAX_RETRIES} retries.")
-            next
-          end
+          response = HttpClient.get("https://registry.npmjs.org/#{name}")
+        rescue Net::OpenTimeout, Net::ReadTimeout
+          next
         end
 
         if response.code != 200
@@ -54,14 +41,7 @@ module SOUP
         package.version = value['version']
         package.license = package_details['license']
         package.license = 'NOASSERTION' if package.license&.include?('Unlicense')
-        description = package_details['description']
-        description = description&.gsub(%r{((?:f|ht)tps?:/\S+)}, '<\1>')
-        description = description&.delete('_')
-        description = description&.delete('[')
-        description = description&.delete(']')
-        description = description&.delete('!')
-        description = description&.delete('|')
-        package.description = description
+        package.description = Package.sanitize_description(package_details['description'], strip_markdown: true)
         package.website = package_details['homepage']
         package.dependency = !main_file.include?(name)
         packages[package.package] = package

--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'httparty'
 require 'json'
 
 require_relative '../package'
@@ -26,7 +25,7 @@ module SOUP
         next if pip_package&.strip&.empty?
 
         puts("Checking #{pip_package} #{version}...")
-        response = RequestWithTimeoutAndRetries.get_with_retries("https://pypi.python.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json")
+        response = HttpClient.get("https://pypi.python.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json")
 
         raise(response.message) unless response.code == 200
 
@@ -35,9 +34,7 @@ module SOUP
         package.file = file
         package.language = 'Python'
         package.version = version
-        description = package_details['info']['summary']&.split(/\n|\. /)&.first
-        description = description&.gsub(%r{((?:f|ht)tps?:/\S+)}, '<\1>')
-        package.description = description
+        package.description = Package.sanitize_description(package_details['info']['summary'], first_sentence: true)
         package.website = package_details['info']['home_page']&.strip
         package.dependency = !main_file.include?(package.package)
 
@@ -54,24 +51,6 @@ module SOUP
         end
 
         packages[package.package] = package
-      end
-    end
-  end
-
-  class RequestWithTimeoutAndRetries
-    include HTTParty
-
-    default_options.update(timeout: 5)
-
-    def self.get_with_retries(url, options = {}, max_retries = 3)
-      retries = 0
-      begin
-        get(url, options)
-      rescue Net::OpenTimeout, Net::ReadTimeout => e
-        raise(e) if retries >= max_retries
-
-        retries += 1
-        retry
       end
     end
   end

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'httparty'
 require 'json'
 
 require_relative '../package'
@@ -21,14 +20,7 @@ module SOUP
 
       raise('No main file found!') if main_file.nil?
 
-      headers =
-        if ENV.fetch('GITHUB_TOKEN', '').empty?
-          nil
-        else
-          {
-            headers: { Authorization: "token #{ENV.fetch('GITHUB_TOKEN', '')}" }
-          }
-        end
+      token = ENV.fetch('GITHUB_TOKEN', '')
 
       lock_file['pins'].each do |pin|
         puts("Checking #{pin['identity'] || pin['package']} #{pin['state']['version']}...")
@@ -36,10 +28,10 @@ module SOUP
         url = "https://api.github.com/repos/#{location.gsub('git@github.com:', '').gsub('https://github.com/', '').gsub('.git', '')}"
 
         response =
-          if headers
-            HTTParty.get(url, headers)
+          if token.empty?
+            HttpClient.get(url)
           else
-            HTTParty.get(url)
+            HttpClient.get(url, headers: { Authorization: "token #{token}" })
           end
 
         raise("Error: #{response.message}! Please set GITHUB_TOKEN.") if response.message.include?('rate limit') || response.message.include?('Bad credentials')
@@ -55,9 +47,7 @@ module SOUP
         package.language = 'Swift'
         package.version = pin['state']['version']&.strip
         package.license = package_details['license']['spdx_id']&.strip
-        description = package_details['description']&.split(/\n|\. /)&.first
-        description = description&.gsub(%r{((?:f|ht)tps?:/\S+)}, '<\1>')
-        package.description = description
+        package.description = Package.sanitize_description(package_details['description'], first_sentence: true)
         package.website = package_details['html_url']&.strip
         package.dependency = !main_file.include?(package.package)
         packages[package.package] = package

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -6,9 +6,6 @@ require_relative '../package'
 
 module SOUP
   class YarnParser
-    MAX_RETRIES = 3
-    private_constant :MAX_RETRIES
-
     def parse(file, packages)
       lock_file = YarnLockParser::Parser.parse(file)
       main_file = File.read(file.gsub('yarn.lock', 'package.json'))
@@ -19,21 +16,10 @@ module SOUP
 
         next if main_file.include?("#{js_package[:name]}\": \"file:vendor")
 
-        response = nil
-        retries = 0
-
         begin
-          response = HTTParty.get("https://registry.npmjs.org/#{js_package[:name]}")
-        rescue Net::OpenTimeout => e
-          retries += 1
-
-          if retries <= MAX_RETRIES
-            puts("Error: #{e.message}. Retrying (#{retries}/#{MAX_RETRIES})...")
-            retry
-          else
-            puts("Error: #{e.message}. Aborting after #{MAX_RETRIES} retries.")
-            next
-          end
+          response = HttpClient.get("https://registry.npmjs.org/#{js_package[:name]}")
+        rescue Net::OpenTimeout, Net::ReadTimeout
+          next
         end
 
         raise(response.message) unless response.code == 200
@@ -45,14 +31,7 @@ module SOUP
         package.version = js_package[:version]
         package.license = package_details['license']
         package.license = 'NOASSERTION' if package.license&.include?('Unlicense')
-        description = package_details['description']
-        description = description&.gsub(%r{((?:f|ht)tps?:/\S+)}, '<\1>')
-        description = description&.delete('_')
-        description = description&.delete('[')
-        description = description&.delete(']')
-        description = description&.delete('!')
-        description = description&.delete('|')
-        package.description = description
+        package.description = Package.sanitize_description(package_details['description'], strip_markdown: true)
         package.website = package_details['homepage']
         package.dependency = !main_file.include?(js_package[:name])
         packages[package.package] = package


### PR DESCRIPTION
## Summary

Refactor common patterns across the codebase to improve maintainability and reduce code duplication (~100 lines net reduction). Three patterns are extracted into shared, reusable components.

**Key changes:**

- Add `PARSER_REGISTRY` hash in `lib/soup/application.rb` to replace the 45-line `case/when` in `detect_packages` with a data-driven registry mapping filenames to parser classes and skip flags
- Remove `PACKAGE_MANAGERS` constant from `lib/soup.rb` (now derived from registry keys)
- Create `lib/soup/http_client.rb` with `HttpClient.get` providing configurable retry (3 retries) and timeout (5s) logic
- Replace duplicated retry code in `lib/soup/parsers/npm.rb` and `lib/soup/parsers/yarn.rb` with `HttpClient.get`
- Remove `RequestWithTimeoutAndRetries` class from `lib/soup/parsers/pip.rb`, replaced by `HttpClient.get`
- Update `lib/soup/parsers/bundler.rb`, `lib/soup/parsers/gradle.rb`, and `lib/soup/parsers/spm.rb` to use `HttpClient.get` for consistent timeout/retry handling
- Add `Package.sanitize_description` class method in `lib/soup/package.rb` with `first_sentence` and `strip_markdown` options
- Replace inline description cleaning in `lib/soup/parsers/npm.rb`, `lib/soup/parsers/yarn.rb`, `lib/soup/parsers/pip.rb`, `lib/soup/parsers/bundler.rb`, `lib/soup/parsers/spm.rb`, and `lib/soup/parsers/composer.rb` with `Package.sanitize_description`
- Remove direct `require 'httparty'` from `bundler.rb`, `pip.rb`, and `spm.rb` (now centralized in `http_client.rb`)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified