### PR TITLE
Update parallel from 2.0.0 to 2.0.1

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -290,7 +290,7 @@
   "parallel": {
     "language": "Ruby",
     "package": "parallel",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "license": "MIT",
     "description": "Run any kind of code in parallel processes",
     "website": "https://github.com/grosser/parallel",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     optparse (0.8.1)
-    parallel (2.0.0)
+    parallel (2.0.1)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -26,7 +26,7 @@
 | Ruby | multi_xml | 0.8.1 | MIT | Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML. | <https://github.com/sferik/multi_xml> | 2026-02-25 | Low | Dependency | Dependency |
 | Ruby | nokogiri | 1.19.2 | MIT | Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby | <https://nokogiri.org> | 2024-05-15 | Low | XML parser | Most popular library |
 | Ruby | optparse | 0.8.1 | Ruby | OptionParser is a class for command-line option analysis | <https://github.com/ruby/optparse> | 2026-02-25 | Low | Used to parse command line arguments. | Very popular on rubygems.org |
-| Ruby | parallel | 2.0.0 | MIT | Run any kind of code in parallel processes | <https://github.com/grosser/parallel> | 2026-02-25 | Low | Dependency | Dependency |
+| Ruby | parallel | 2.0.1 | MIT | Run any kind of code in parallel processes | <https://github.com/grosser/parallel> | 2026-02-25 | Low | Dependency | Dependency |
 | Ruby | parser | 3.3.11.1 | MIT | A Ruby parser written in pure Ruby. | <https://github.com/whitequark/parser> | 2026-02-25 | Low | Dependency | Dependency |
 | Ruby | pastel | 0.8.0 | MIT | Terminal strings styling with intuitive and clean API. | <https://ttytoolkit.org> | 2024-08-07 | Low | Dependency | Dependency |
 | Ruby | prism | 1.9.0 | MIT | Prism Ruby parser | <https://github.com/ruby/prism> | 2025-03-31 | Low | Dependency | Dependency |


### PR DESCRIPTION
## Summary

Update the parallel gem from version 2.0.0 to 2.0.1 in Gemfile.lock.

**Key changes:**
- Bump parallel gem version from 2.0.0 to 2.0.1

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency version bump only, no code changes
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
