### PR TITLE
Add issues write permission to auto-merge workflow and refine SOUP doc

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,6 +9,7 @@ name: Auto-merge for code owners
     - synchronize
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 jobs:
   enable_automerge:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@
 
 ### SOUP Module
 
-**Purpose:** Root module defining constants and configuration for supported package managers and risk levels.
+**Purpose:** Root module defining the IEC 62304 risk level constants used throughout the application.
 
 **Location:** `lib/soup.rb`
 


### PR DESCRIPTION
## Summary

Grants the auto-merge workflow permission to write to issues, allowing it to perform issue-related operations on pull requests, and tightens the SOUP module description in the architecture documentation to accurately reflect its current responsibility.

**Key changes:**

- Add `issues: write` permission to `.github/workflows/auto-merge.yml` so the auto-merge workflow can interact with issue/PR APIs that require it.
- Update the SOUP Module purpose in `docs/architecture.md` to specify it defines IEC 62304 risk level constants, replacing the broader (and now inaccurate) wording about package managers and configuration.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Changes are limited to a workflow permission and a documentation string; no runtime code paths are affected.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
