### PR TITLE
Remove auto-merge step from auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -77,10 +77,3 @@ jobs:
       env:
         GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
         PR: "${{github.event.pull_request.number}}"
-    - name: Enable auto-merge
-      shell: bash
-      if: steps.check.outputs.is_owner == 'true'
-      run: gh pr merge --auto --squash "$PR"
-      env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
-        PR: "${{github.event.pull_request.number}}"


### PR DESCRIPTION
## Summary

Removes the final `Enable auto-merge` step from the auto-merge GitHub Actions workflow. The workflow no longer invokes `gh pr merge --auto --squash` after the ownership check, leaving the prior steps in place without automatically queueing PRs for merge.

**Key changes:**

- Removed the `Enable auto-merge` step (and its `gh pr merge --auto --squash` call) from `.github/workflows/auto-merge.yml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): CI workflow change — disables the auto-merge action step

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Workflow file change with no application logic to unit test
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
