### PR TITLE
Update multi_xml from 0.9.0 to 0.9.1 and ignore code-review.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -534,3 +534,4 @@ $RECYCLE.BIN/
 
 # RSpec
 .rspec_status
+docs/code-review.md

--- a/.soup.json
+++ b/.soup.json
@@ -254,7 +254,7 @@
   "multi_xml": {
     "language": "Ruby",
     "package": "multi_xml",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "license": "MIT",
     "description": "Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML.",
     "website": "https://github.com/sferik/multi_xml",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    multi_xml (0.9.0)
+    multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -23,7 +23,7 @@
 | Ruby | logger | 1.7.0 | Ruby | Provides a simple logging utility for outputting messages. | <https://github.com/ruby/logger> | 2024-08-12 | Low | Dependency | Dependency |
 | Ruby | mini_mime | 1.1.5 | MIT | A minimal mime type library | <https://github.com/discourse/mini_mime> | 2023-03-30 | Low | Dependency | Dependency |
 | Ruby | minitest | 6.0.6 | MIT | minitest provides a complete suite of testing facilities supporting | <https://minite.st/> | 2026-02-25 | Low | Dependency | Dependency |
-| Ruby | multi_xml | 0.9.0 | MIT | Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML. | <https://github.com/sferik/multi_xml> | 2026-02-25 | Low | Dependency | Dependency |
+| Ruby | multi_xml | 0.9.1 | MIT | Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML. | <https://github.com/sferik/multi_xml> | 2026-02-25 | Low | Dependency | Dependency |
 | Ruby | nokogiri | 1.19.3 | MIT | Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby | <https://nokogiri.org> | 2024-05-15 | Low | XML parser | Most popular library |
 | Ruby | optparse | 0.8.1 | Ruby | OptionParser is a class for command-line option analysis | <https://github.com/ruby/optparse> | 2026-02-25 | Low | Used to parse command line arguments. | Very popular on rubygems.org |
 | Ruby | parallel | 2.1.0 | MIT | Run any kind of code in parallel processes | <https://github.com/grosser/parallel> | 2026-02-25 | Low | Dependency | Dependency |


### PR DESCRIPTION
## Summary

Routine dependency maintenance and a tooling-related ignore rule update.

**Key changes:**

- Bump `multi_xml` from 0.9.0 to 0.9.1 in `Gemfile.lock`.
- Add `docs/code-review.md` to `.gitignore` so locally generated code review output is not committed.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency patch bump and gitignore update — no logic changes to test.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] ``readme.md`` includes sections on introduction, installation, usage, and contributing
- [x] ``docs/architecture.md`` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified