### PR TITLE
Parse gradle.lockfile runtime classpath alongside buildscript-gradle.lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following package managers are supported:
 
 * Bundler (Gemfile.lock)
 * Composer (composer.lock)
-* Gradle (buildscript-gradle.lockfile)
+* Gradle (buildscript-gradle.lockfile, gradle.lockfile)
 * NPM (package-lock.json)
 * PIP (requirements.txt)
 * SPM (Package.resolved)
@@ -71,7 +71,7 @@ options
         --no_prompt                  Do not prompt for missing information and fail immediately
         --skip_bundler               Ignore Ruby/Bundler/Gemfile/Gemfile.lock even if detected
         --skip_composer              Ignore PHP/Composer/composer.json/composer.lock even if detected
-        --skip_gradle                Ignore Kotlin/Gradle/build.gradle/buildscript-gradle.lockfile even if detected
+        --skip_gradle                Ignore Kotlin/Gradle/build.gradle/buildscript-gradle.lockfile/gradle.lockfile even if detected
         --skip_npm                   Ignore JS/NPM/package.json/package-lock.json even if detected
         --skip_pip                   Ignore Python/PIP/requirements.txt even if detected
         --skip_spm                   Ignore Swift/SPM/Package.swift/Package.resolved even if detected

--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -26,6 +26,7 @@ module SOUP
     'buildscript-gradle.lockfile': { parser: GradleParser, skip: :skip_gradle },
     'composer.lock': { parser: ComposerParser, skip: :skip_composer },
     'Gemfile.lock': { parser: BundlerParser, skip: :skip_bundler },
+    'gradle.lockfile': { parser: GradleParser, skip: :skip_gradle },
     'Package.resolved': { parser: SPMParser, skip: :skip_spm },
     'package-lock.json': { parser: NPMParser, skip: :skip_npm },
     'Podfile.lock': { parser: nil, skip: :skip_cocoapods }, # Disabled: cocoapods-core requires activesupport < 8

--- a/lib/soup/options.rb
+++ b/lib/soup/options.rb
@@ -91,7 +91,7 @@ module SOUP
         @skip_composer = true
       end
 
-      @parser.on('', '--skip_gradle', 'Ignore Kotlin/Gradle/build.gradle/buildscript-gradle.lockfile even if detected') do
+      @parser.on('', '--skip_gradle', 'Ignore Kotlin/Gradle/build.gradle/buildscript-gradle.lockfile/gradle.lockfile even if detected') do
         @skip_gradle = true
       end
 

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -11,14 +11,21 @@ module SOUP
 
     def parse(file, packages)
       lock_file = File.readlines(file)
-      main_file = File.read(file.gsub('buildscript-gradle.lockfile', 'build.gradle'))
+      main_file = File.read(file.sub(/(?:buildscript-)?gradle\.lockfile\z/, 'build.gradle'))
+      is_buildscript = File.basename(file) == 'buildscript-gradle.lockfile'
 
       lock_file.each do |line|
         next if line.strip.start_with?('#')
 
         package_name, type = line.strip.split('=')
 
-        next unless type == 'classpath'
+        if is_buildscript
+          next unless type == 'classpath'
+        else
+          next unless type&.split(',')&.any? do |config|
+            config.end_with?('RuntimeClasspath') && !config.include?('Test') && !config.include?('Debug')
+          end
+        end
 
         group_id, artifact_id, version = package_name.split(':')
         puts("Checking #{group_id}:#{artifact_id} #{version}...")

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -174,4 +174,53 @@ RSpec.describe(SOUP::GradleParser) do
       expect(packages['com.example:library'].dependency).to(be(true))
     end
   end
+
+  context 'when parsing an application gradle.lockfile (runtime classpath)' do
+    let(:runtime_lock_content) do
+      [
+        "# Gradle dependency lock file\n",
+        "androidx.activity:activity-compose:1.10.1=googleProdDebugRuntimeClasspath,googleProdReleaseRuntimeClasspath\n",
+        "androidx.test:runner:1.5.2=googleProdReleaseUnitTestRuntimeClasspath\n",
+        "com.example:debug-only:1.0.0=googleProdDebugRuntimeClasspath\n",
+        "com.example:compile-only:1.0.0=googleProdReleaseCompileClasspath\n",
+        "com.example:runtime-lib:2.0.0=runtimeClasspath\n",
+        "empty:no-config:0=\n"
+      ]
+    end
+
+    before do
+      allow(File).to(receive(:readlines).with('app/gradle.lockfile').and_return(runtime_lock_content))
+      allow(File).to(receive(:read).with('app/build.gradle').and_return('implementation "androidx.activity:activity-compose:1.10.1"'))
+
+      stub_request(:get, %r{search\.maven\.org/solrsearch/select})
+        .to_return(status: 200, body: maven_response)
+    end
+
+    it 'derives the build.gradle path from the lockfile location' do
+      packages = {}
+      expect { parser.parse('app/gradle.lockfile', packages) }.not_to(raise_error)
+    end
+
+    it 'includes production runtime classpath entries', :aggregate_failures do
+      packages = {}
+      parser.parse('app/gradle.lockfile', packages)
+      expect(packages).to(have_key('androidx.activity:activity-compose'))
+      expect(packages).to(have_key('com.example:runtime-lib'))
+    end
+
+    it 'excludes test, debug-only, and compile-only configurations', :aggregate_failures do
+      packages = {}
+      parser.parse('app/gradle.lockfile', packages)
+      expect(packages).not_to(have_key('androidx.test:runner'))
+      expect(packages).not_to(have_key('com.example:debug-only'))
+      expect(packages).not_to(have_key('com.example:compile-only'))
+    end
+
+    it 'flags transitive dependencies not declared in build.gradle' do
+      packages = {}
+      parser.parse('app/gradle.lockfile', packages)
+      expect(packages['com.example:runtime-lib'].dependency).to(be(true))
+      expect(packages['androidx.activity:activity-compose'].dependency).to(be(false))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The gradle parser currently only reads `buildscript-gradle.lockfile` and filters to lines tagged `=classpath`. That captures Gradle-plugin / build-tool dependencies but misses every runtime dependency of the application itself (Compose, Firebase, OkHttp, etc.), which Gradle locks into a separate `gradle.lockfile` under each module with config-specific tags like `googleProdReleaseRuntimeClasspath`.

Result for affected projects: `docs/soup.md` ends up listing only build-classpath dependencies, with 0 entries for the actual third-party code shipping to users — which defeats the SOUP/IEC 62304 purpose the tool exists for.

## Changes

- `lib/soup/parsers/gradle.rb`: also handle `gradle.lockfile`. For the new case, include packages that appear in any configuration ending in `RuntimeClasspath` and not containing `Test` or `Debug` (i.e. production runtime). The existing strict `type == 'classpath'` filter is preserved for `buildscript-gradle.lockfile`, so current users see no change. Also fixes the `build.gradle` path derivation so it works for lockfiles in subdirectories.
- `lib/soup/application.rb`: register `gradle.lockfile` in `PARSER_REGISTRY` against the existing `GradleParser`.
- `spec/soup/gradle_parser_spec.rb`: new context covering inclusion of production runtime entries, exclusion of test / debug / compile-only configs, and direct-vs-transitive dependency flagging via `build.gradle`.
- `README.md` and `lib/soup/options.rb`: mention `gradle.lockfile` in the supported-formats list and the `--skip_gradle` help text.

## Behavior change

- Projects with only a `buildscript-gradle.lockfile`: no change.
- Projects with a `gradle.lockfile` (Android / Gradle projects using dependency locking on runtime classpaths): `docs/soup.md` will now include their runtime dependencies. Existing `.soup.json` cache entries are preserved by the normal merge path.

## Test plan

- [ ] `bundle exec rspec spec/soup/gradle_parser_spec.rb`
- [ ] `bundle exec rspec` (full suite still green)
- [ ] Smoke run against a project that has both a `buildscript-gradle.lockfile` and an `app/gradle.lockfile`; confirm the resulting `soup.md` now contains runtime deps (Compose / Firebase / etc.) and that previously-listed build-classpath deps are still present.