### PR TITLE
Update Ubuntu base image to 26.04 and pin macOS runner to macos-26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ permissions:
   pull-requests: read
 env:
   RUBY-BUNDLER-CACHE: 'false'
-  XCODE-VERSION: 26.5
 jobs:
   variables:
     name: Prepare Variables
@@ -188,7 +187,6 @@ jobs:
       if: "${{needs.variables.outputs.SKIP_LICENSES != '1' || needs.variables.outputs.SKIP_TESTS != '1'}}"
       with:
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
-        xcode-version: "${{env.XCODE-VERSION}}"
         github-token: "${{secrets.GH_PAT}}"
     - name: Bundler
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 env:
   RUBY-BUNDLER-CACHE: 'false'
-  XCODE-VERSION: 16.4.0
+  XCODE-VERSION: 26.5
 jobs:
   variables:
     name: Prepare Variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-latest
+        - macos-26
         - ubuntu-latest
     steps:
     - name: Setup

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,7 +5,7 @@ name: Cron Dependencies
   - cron: 0 9 * * 1
 env:
   RUBY-BUNDLER-CACHE: 'false'
-  XCODE-VERSION: 16.4.0
+  XCODE-VERSION: 26.5
 jobs:
   update_dependencies:
     name: Update Dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,7 +5,6 @@ name: Cron Dependencies
   - cron: 0 9 * * 1
 env:
   RUBY-BUNDLER-CACHE: 'false'
-  XCODE-VERSION: 26.5
 jobs:
   update_dependencies:
     name: Update Dependencies
@@ -22,7 +21,6 @@ jobs:
       uses: cloud-officer/ci-actions/setup@v2
       with:
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
-        xcode-version: "${{env.XCODE-VERSION}}"
         github-token: "${{secrets.GH_PAT}}"
     - name: Close Stale Dependency PRs
       shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use Ubuntu 24.04 as the base image
-FROM ubuntu:24.04
+# Use Ubuntu 26.04 as the base image
+FROM ubuntu:26.04
 
 # Labels
 LABEL org.opencontainers.image.source=https://github.com/Cloud-Officer/soup


### PR DESCRIPTION
## Summary

Bumps the build environment to the latest OS versions. The Dockerfile now builds on Ubuntu 26.04 and the GitHub Actions macOS job pins to the `macos-26` runner instead of `macos-latest` to align with the new Ubuntu major and ensure deterministic macOS builds.

**Key changes:**

- Update `Dockerfile` base image from `ubuntu:24.04` to `ubuntu:26.04`.
- Pin GitHub Actions build matrix from `macos-latest` to `macos-26` in `.github/workflows/build.yml`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Build/runner version bump validated via CI.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified