### PR TITLE
Fix NPM dependency classification and sanitize multi-line descriptions

### DIFF
--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -71,8 +71,12 @@ module SOUP
     end
 
     def markdown_cell(value)
-      return ' ' if value.nil? || value.to_s.strip.empty?
+      value = value.to_s
+      return ' ' if value.strip.empty?
 
+      # Collapse any whitespace run (including embedded newlines and tabs) to a single
+      # space so a multi-line package description does not break the markdown table.
+      value = value.gsub(/\s+/, ' ')
       # Strip leading/trailing spaces inside backtick code spans (MD038 lint rule)
       # Using [^`]* instead of \s*(.*?)\s* to avoid ReDoS vulnerability
       value = value.strip.gsub(/`([^`]*)`/) { "`#{Regexp.last_match(1).strip}`" }

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -80,7 +80,7 @@ module SOUP
       package.language = 'Kotlin'
       package.version = version
       package.license = license
-      package.description = description
+      package.description = Package.sanitize_description(description)
       package.website = website
       package.dependency = !main_file.include?("#{group_id}:#{artifact_id}")
       package

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -9,14 +9,16 @@ module SOUP
   class NPMParser
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
-      main_file = File.read(file.gsub('package-lock.json', 'package.json'))
+      main_file_json = JSON.parse(File.read(file.gsub('package-lock.json', 'package.json')))
+      direct_deps = (main_file_json['dependencies'] || {}).keys |
+                    (main_file_json['devDependencies'] || {}).keys
       all_packages = lock_file['packages']
 
       work_items = all_packages.reject { |key, value| key.empty? || value['dev'] }
 
       results =
         Parallel.map(work_items, in_threads: HttpClient::THREAD_COUNT) do |key, value|
-          fetch_package(file, main_file, key, value)
+          fetch_package(file, direct_deps, key, value)
         end
 
       results.compact.each { |package| packages[package.package] = package }
@@ -24,7 +26,7 @@ module SOUP
 
     private
 
-    def fetch_package(file, main_file, key, value)
+    def fetch_package(file, direct_deps, key, value)
       name = key.split('node_modules/').last
       puts("Checking #{name} #{value['version']}...")
 
@@ -57,11 +59,12 @@ module SOUP
       package.file = file
       package.language = 'JS'
       package.version = value['version']
-      package.license = package_details['license']
-      package.license = 'NOASSERTION' if package.license&.include?('Unlicense')
+      raw_license = package_details['license']
+      package.license = raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
+      package.license = 'NOASSERTION' if package.license.include?('Unlicense')
       package.description = Package.sanitize_description(package_details['description'], strip_markdown: true)
       package.website = package_details['homepage']
-      package.dependency = !main_file.include?(name)
+      package.dependency = !direct_deps.include?(name)
       package
     end
   end

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -132,4 +132,47 @@ RSpec.describe(SOUP::NPMParser) do
       expect(packages).to(be_empty)
     end
   end
+
+  context 'when package only appears in package.json overrides' do
+    let(:main_file) { '{"dependencies":{"lodash":"^4.17.0"},"overrides":{"lodash":"4.17.21"}}' }
+
+    before do
+      stub_request(:get, 'https://registry.npmjs.org/lodash')
+        .to_return(status: 200, body: registry_response)
+    end
+
+    it 'classifies overrides-only packages as transitive (not direct)' do
+      packages = {}
+      parser.parse('package-lock.json', packages)
+      expect(packages['lodash'].dependency).to(be(false))
+    end
+  end
+
+  context 'when package is in overrides but not declared as a direct dep' do
+    let(:lock_file) do
+      {
+        packages: {
+          '': { version: '1.0.0' }, # rubocop:disable Naming/VariableNumber
+          'node_modules/transitive-only': { version: '1.0.0' }
+        }
+      }.to_json
+    end
+
+    let(:main_file) { '{"dependencies":{},"overrides":{"transitive-only":"1.0.0"}}' }
+
+    let(:transitive_response) do
+      { versions: { '1.0.0': { license: 'MIT', description: 'x', homepage: 'https://example.com' } } }.to_json
+    end
+
+    before do
+      stub_request(:get, 'https://registry.npmjs.org/transitive-only')
+        .to_return(status: 200, body: transitive_response)
+    end
+
+    it 'is treated as transitive even though it appears in overrides' do
+      packages = {}
+      parser.parse('package-lock.json', packages)
+      expect(packages['transitive-only'].dependency).to(be(true))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR fixes two correctness issues in the SOUP report. NPM packages were being misclassified as direct dependencies when their name happened to appear anywhere in `package.json` (including the `overrides`, `resolutions`, or `scripts` blocks), because the parser ran a raw substring search on the file contents. The parser now reads `package.json` as JSON and only treats keys from `dependencies` and `devDependencies` as direct deps. The NPM parser also previously crashed when a registry response returned a `license` object (e.g. `{ "type": "MIT", "url": "..." }`) instead of a plain string. Separately, multi-line package descriptions coming from npm/Gradle were leaking embedded newlines into the markdown table cells, breaking the rendered SOUP document; whitespace runs are now collapsed before insertion.

**Key changes:**

- `lib/soup/parsers/npm.rb`: parse `package.json` as JSON and derive direct deps from `dependencies` + `devDependencies` keys instead of substring-matching the raw file
- `lib/soup/parsers/npm.rb`: handle `license` returned as either a string or a `{ "type": "..." }` hash, and use `String#include?` safely on the normalized value
- `lib/soup/parsers/gradle.rb`: sanitize Gradle package descriptions via `Package.sanitize_description` for parity with the NPM parser
- `lib/soup/application.rb`: in `markdown_cell`, coerce input to string and collapse all whitespace runs (newlines, tabs, repeated spaces) to a single space so multi-line descriptions don't break the markdown table layout
- `spec/soup/npm_parser_spec.rb`: add coverage for overrides-only packages being classified as transitive

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified