### PR TITLE
Document parallel metadata fetching across SOUP parsers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,10 +172,12 @@
 
 - `MAX_RETRIES`: Maximum retry attempts (3)
 - `DEFAULT_TIMEOUT`: HTTP request timeout in seconds (5)
+- `THREAD_COUNT`: Public constant set to `Etc.nprocessors`; used by all parsers as the thread-pool size for parallel metadata fetching
 - `self.get(url, max_retries:, **options)`: Performs HTTP GET with automatic retry on `Net::OpenTimeout` and `Net::ReadTimeout`
 
 **External Dependencies:**
 
+- `etc`
 - `httparty`
 
 ### SOUP::GenericParser
@@ -196,11 +198,12 @@
 
 **Key Components:**
 
-- `parse(file, packages)`: Parses lock file and fetches package details from RubyGems
+- `parse(file, packages)`: Parses lock file and fetches package details from RubyGems, fetching metadata for all specs in parallel via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)`
 
 **External Dependencies:**
 
 - `bundler`
+- `parallel`
 
 ### SOUP::CocoaPodsParser
 
@@ -236,12 +239,13 @@
 
 **Key Components:**
 
-- `parse(file, packages)`: Parses lock file and fetches package details from Maven Central or fallback repositories. Selects `classpath` entries for `buildscript-gradle.lockfile` and non-test, non-debug `RuntimeClasspath` entries for `gradle.lockfile`
+- `parse(file, packages)`: Parses lock file and fetches package details from Maven Central or fallback repositories, in parallel via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)`. Selects `classpath` entries for `buildscript-gradle.lockfile` and non-test, non-debug `RuntimeClasspath` entries for `gradle.lockfile`
 - `REPOSITORY_URLS`: List of Maven repository URLs for fallback lookups
 
 **External Dependencies:**
 
 - `nokogiri`
+- `parallel`
 
 ### SOUP::NPMParser
 
@@ -251,7 +255,11 @@
 
 **Key Components:**
 
-- `parse(file, packages)`: Parses lock file and fetches package details from NPM registry
+- `parse(file, packages)`: Parses lock file and fetches package details from NPM registry in parallel via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)`
+
+**External Dependencies:**
+
+- `parallel`
 
 ### SOUP::PIPParser
 
@@ -261,7 +269,11 @@
 
 **Key Components:**
 
-- `parse(file, packages)`: Parses requirements file and fetches package details from PyPI
+- `parse(file, packages)`: Parses requirements file and fetches package details from PyPI in parallel via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)`
+
+**External Dependencies:**
+
+- `parallel`
 
 ### SOUP::SPMParser
 
@@ -271,8 +283,12 @@
 
 **Key Components:**
 
-- `parse(file, packages)`: Parses resolved file and fetches package details from GitHub API
+- `parse(file, packages)`: Parses resolved file and fetches package details from GitHub API in parallel via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)`
 - Supports `GITHUB_TOKEN` environment variable for rate limit handling
+
+**External Dependencies:**
+
+- `parallel`
 
 ### SOUP::YarnParser
 
@@ -282,10 +298,11 @@
 
 **Key Components:**
 
-- `parse(file, packages)`: Parses lock file and fetches package details from NPM registry
+- `parse(file, packages)`: Parses lock file and fetches package details from NPM registry in parallel via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)`
 
 **External Dependencies:**
 
+- `parallel`
 - `yarn_lock_parser`
 
 ## Software of Unknown Provenance
@@ -386,6 +403,19 @@ Validation criteria for SOUP entries: Accuracy (Requirements match actual usage)
    - Logs retry attempt with counter
    - Retries up to `MAX_RETRIES` (3) times
    - Raises the exception after max retries are exhausted
+
+### Parallel Metadata Fetching Algorithm
+
+**Purpose:** Speeds up registry lookups by fetching package metadata concurrently instead of serially.
+
+**Location:** `parse` method of the Bundler, Gradle, NPM, PIP, SPM, and Yarn parsers in `lib/soup/parsers/`
+
+**Implementation:**
+
+1. Builds a work-item list of packages discovered in the lock file
+2. Processes the list with `Parallel.map(work_items, in_threads: HttpClient::THREAD_COUNT)`
+3. `THREAD_COUNT` is `Etc.nprocessors`, sizing the thread pool to the available CPU cores
+4. Each thread fetches metadata through `SOUP::HttpClient.get` (which applies its own timeout and retry logic)
 
 ## Risk controls
 


### PR DESCRIPTION
## Summary

Updates `docs/architecture.md` to reflect the parallelized parser HTTP
fetching introduced in #320. The documentation now describes the shared
`HttpClient::THREAD_COUNT` constant, the `parallel` gem dependency added
to each parser, and the parallel metadata fetching algorithm.

**Key changes:**

- Document `HttpClient::THREAD_COUNT` (set to `Etc.nprocessors`) and the new `etc` external dependency in the HttpClient section
- Update Bundler, Gradle, NPM, PIP, SPM, and Yarn parser descriptions to note metadata is fetched in parallel via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)`
- Add `parallel` to the External Dependencies list for each affected parser
- Add a new "Parallel Metadata Fetching Algorithm" section under critical algorithms describing purpose, location, and implementation

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified