### PR TITLE
Extract BaseParser scaffold and split check_packages into focused helpers

### DIFF
--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -35,6 +35,7 @@ module SOUP
   }.freeze
 
   private_constant :PARSER_REGISTRY
+
   # Represents an instance of a soup application. This is the entry point for all invocations of soup from the command line.
   class Application
     def initialize(argv)
@@ -132,82 +133,116 @@ module SOUP
       prompt = TTY::Prompt.new
 
       @detected_packages.each do |name, package|
-        if @options.licenses_check && !package.license.nil? && !package.license.empty?
-          found = false
-
-          licenses.each do |license|
-            if package.license.downcase.include?(license)
-              found = true
-              break
-            end
-          end
-
-          found = true if exceptions.include?(package.package)
-
-          unless found
-            puts("Invalid license #{package.license} found in #{package.file} in package #{package.package}!")
-            @exit_code = Status::ERROR_EXIT_CODE if package.license != 'NOASSERTION'
-          end
-        end
+        validate_license(package, licenses, exceptions)
 
         next unless @options.soup_check
 
-        if @cached_packages[name]
-          package.last_verified_at = @cached_packages[name]['last_verified_at']
-          package.risk_level = @cached_packages[name]['risk_level']
-          package.requirements = @cached_packages[name]['requirements']
-          package.verification_reasoning = @cached_packages[name]['verification_reasoning']
-        end
-
-        if package.dependency
-          package.risk_level = RISK_LEVELS_SCREEN.first.split.first
-          package.requirements = DEPENDENCY_TEXT
-          package.verification_reasoning = DEPENDENCY_TEXT
-        end
-
-        if package.risk_level.empty?
-          if @options.auto_reply
-            package.risk_level = RISK_LEVELS_SCREEN.first.split.first
-          else
-            raise("No risk level found for #{package.package}!") if @options.no_prompt
-
-            package.risk_level = prompt.select("Enter risk level for package #{package.package}", RISK_LEVELS_SCREEN).split.first
-          end
-        end
-
-        if package.requirements.empty?
-          if @options.auto_reply
-            package.requirements = DEPENDENCY_TEXT
-          else
-            raise("No requirements found for #{package.package}!") if @options.no_prompt
-
-            package.requirements = prompt.ask("Enter requirements for package #{package.package}: ")
-          end
-        end
-
-        if package.verification_reasoning.empty?
-          if @options.auto_reply
-            package.verification_reasoning = DEPENDENCY_TEXT
-          else
-            raise("No verification reasoning found for #{package.package}!") if @options.no_prompt
-
-            package.verification_reasoning = prompt.ask("Enter verification reasoning for package #{package.package}: ")
-          end
-        end
-
-        raise("Missing information for #{package.package}!") if package.risk_level.empty? or package.requirements.empty? or package.verification_reasoning.empty?
+        apply_cached_metadata(name, package)
+        apply_dependency_defaults(package)
+        prompt_for_metadata(package, prompt)
+        ensure_metadata_complete!(package)
 
         package.last_verified_at = Time.now.strftime('%Y-%m-%d').to_s if package.last_verified_at.empty?
 
-        if package.description
-          package.description = package.description.delete('|')
-          package.description = package.description.gsub('  ', ' ')
-          package.description = Nokogiri::HTML.fragment(package.description).text
-        end
-
-        website = package.website.to_s.strip.empty? ? '' : "<#{package.website}>"
-        @markdown += "|#{markdown_cell(package.language)}|#{markdown_cell(package.package)}|#{markdown_cell(package.version)}|#{markdown_cell(package.license)}|#{markdown_cell(package.description)}|#{markdown_cell(website)}|#{markdown_cell(package.last_verified_at)}|#{markdown_cell(package.risk_level)}|#{markdown_cell(package.requirements)}|#{markdown_cell(package.verification_reasoning)}|\n"
+        append_markdown_row(package)
       end
+    end
+
+    def validate_license(package, licenses, exceptions)
+      return unless @options.licenses_check
+      return if package.license.nil? || package.license.empty?
+      return if licenses.any? { |license| package.license.downcase.include?(license) }
+      return if exceptions.include?(package.package)
+
+      puts("Invalid license #{package.license} found in #{package.file} in package #{package.package}!")
+      @exit_code = Status::ERROR_EXIT_CODE if package.license != 'NOASSERTION'
+    end
+
+    def apply_cached_metadata(name, package)
+      cached = @cached_packages[name]
+      return unless cached
+
+      package.last_verified_at = cached['last_verified_at']
+      package.risk_level = cached['risk_level']
+      package.requirements = cached['requirements']
+      package.verification_reasoning = cached['verification_reasoning']
+    end
+
+    def apply_dependency_defaults(package)
+      return unless package.dependency
+
+      package.risk_level = RISK_LEVELS_SCREEN.first.split.first
+      package.requirements = DEPENDENCY_TEXT
+      package.verification_reasoning = DEPENDENCY_TEXT
+    end
+
+    def prompt_for_metadata(package, prompt)
+      prompt_missing_field(
+        package,
+        prompt,
+        field: :risk_level,
+        label: 'risk level',
+        default_value: RISK_LEVELS_SCREEN.first.split.first
+      ) { |p, pkg| p.select("Enter risk level for package #{pkg.package}", RISK_LEVELS_SCREEN).split.first }
+
+      prompt_missing_field(
+        package,
+        prompt,
+        field: :requirements,
+        label: 'requirements',
+        default_value: DEPENDENCY_TEXT
+      ) { |p, pkg| p.ask("Enter requirements for package #{pkg.package}: ") }
+
+      prompt_missing_field(
+        package,
+        prompt,
+        field: :verification_reasoning,
+        label: 'verification reasoning',
+        default_value: DEPENDENCY_TEXT
+      ) { |p, pkg| p.ask("Enter verification reasoning for package #{pkg.package}: ") }
+    end
+
+    def prompt_missing_field(package, prompt, field:, label:, default_value:)
+      return unless package.public_send(field).to_s.empty?
+
+      if @options.auto_reply
+        package.public_send(:"#{field}=", default_value)
+        return
+      end
+
+      raise("No #{label} found for #{package.package}!") if @options.no_prompt
+
+      package.public_send(:"#{field}=", yield(prompt, package))
+    end
+
+    def ensure_metadata_complete!(package)
+      return unless package.risk_level.empty? || package.requirements.empty? || package.verification_reasoning.empty?
+
+      raise("Missing information for #{package.package}!")
+    end
+
+    def append_markdown_row(package)
+      if package.description
+        package.description = package.description.delete('|')
+        package.description = package.description.gsub('  ', ' ')
+        package.description = Nokogiri::HTML.fragment(package.description).text
+      end
+
+      website = package.website.to_s.strip.empty? ? '' : "<#{package.website}>"
+      cells =
+        [
+          package.language,
+          package.package,
+          package.version,
+          package.license,
+          package.description,
+          website,
+          package.last_verified_at,
+          package.risk_level,
+          package.requirements,
+          package.verification_reasoning
+        ].map { |cell| markdown_cell(cell) }
+      @markdown += "|#{cells.join('|')}|\n"
     end
 
     def save_files

--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'parallel'
+
+require_relative '../http_client'
+require_relative '../package'
+
+module SOUP
+  class BaseParser
+    NOASSERTION_LICENSE = 'NOASSERTION'
+    public_constant :NOASSERTION_LICENSE
+
+    UNLICENSE_PATTERN = 'Unlicense'
+    private_constant :UNLICENSE_PATTERN
+
+    def parse(_file, _packages)
+      raise(NotImplementedError, "#{self.class} must implement #parse")
+    end
+
+    protected
+
+    def parallel_each(work_items, packages, &)
+      results = Parallel.map(work_items, in_threads: HttpClient::THREAD_COUNT, &)
+      collect_packages(results, packages)
+    end
+
+    def collect_packages(results, packages)
+      results.compact.each { |package| packages[package.package] = package }
+    end
+
+    def build_package(name:, file:, language:, version:, license:, description:, website:, dependency:)
+      package = Package.new(name)
+      package.file = file
+      package.language = language
+      package.version = version
+      package.license = normalize_license(license)
+      package.description = description
+      package.website = website
+      package.dependency = dependency
+      package
+    end
+
+    def normalize_license(license)
+      return license if license.nil?
+      return license if license.respond_to?(:empty?) && license.empty?
+      return NOASSERTION_LICENSE if license.to_s.include?(UNLICENSE_PATTERN)
+      return NOASSERTION_LICENSE if license.to_s.start_with?('http')
+
+      license
+    end
+  end
+end

--- a/lib/soup/parsers/bundler.rb
+++ b/lib/soup/parsers/bundler.rb
@@ -2,23 +2,18 @@
 
 require 'bundler'
 require 'json'
-require 'parallel'
 
-require_relative '../http_client'
-require_relative '../package'
+require_relative 'base'
 
 module SOUP
-  class BundlerParser
+  class BundlerParser < BaseParser
     def parse(file, packages)
       lock_file = Bundler::LockfileParser.new(Bundler.read_file(file))
       main_file = File.read(file.sub(/\.lock$/, ''))
 
-      results =
-        Parallel.map(lock_file.specs, in_threads: HttpClient::THREAD_COUNT) do |spec|
-          fetch_package(file, main_file, spec)
-        end
-
-      results.compact.each { |package| packages[package.package] = package }
+      parallel_each(lock_file.specs, packages) do |spec|
+        fetch_package(file, main_file, spec)
+      end
     end
 
     private
@@ -39,15 +34,17 @@ module SOUP
       end
 
       package_details = JSON.parse(response.body)
-      package = Package.new(spec.name)
-      package.file = file
-      package.language = 'Ruby'
-      package.version = spec.version&.to_s&.strip
-      package.license = package_details['licenses']&.first&.strip
-      package.description = Package.sanitize_description(package_details['info'], first_sentence: true)
-      package.website = package_details['homepage_uri']&.strip
-      package.dependency = !main_file.include?(package.package)
-      package
+
+      build_package(
+        name: spec.name,
+        file: file,
+        language: 'Ruby',
+        version: spec.version&.to_s&.strip,
+        license: package_details['licenses']&.first&.strip,
+        description: Package.sanitize_description(package_details['info'], first_sentence: true),
+        website: package_details['homepage_uri']&.strip,
+        dependency: !main_file.include?(spec.name)
+      )
     end
   end
 end

--- a/lib/soup/parsers/composer.rb
+++ b/lib/soup/parsers/composer.rb
@@ -2,10 +2,10 @@
 
 require 'json'
 
-require_relative '../package'
+require_relative 'base'
 
 module SOUP
-  class ComposerParser
+  class ComposerParser < BaseParser
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
       main_file = File.read(file.gsub('lock', 'json'))
@@ -13,21 +13,28 @@ module SOUP
 
       all_packages.each do |php_package|
         puts("Checking #{php_package['name']} #{php_package['version']}...")
-        package = Package.new(php_package['name'])
-        package.file = file
-        package.language = 'PHP'
-        package.version = php_package['version']&.strip
-        license = php_package['license']&.first
-        license = license&.tr('()', '  ')
-        license = license&.strip
-        license = license&.split&.first
-        package.license = license
-        package.license = 'NOASSERTION' if package.license&.start_with?('http')
-        package.description = Package.sanitize_description(php_package['description'], first_sentence: true)
-        package.website = php_package['homepage']&.strip
-        package.dependency = !main_file.include?(package.package)
+
+        package = build_package(
+          name: php_package['name'],
+          file: file,
+          language: 'PHP',
+          version: php_package['version']&.strip,
+          license: extract_composer_license(php_package['license']),
+          description: Package.sanitize_description(php_package['description'], first_sentence: true),
+          website: php_package['homepage']&.strip,
+          dependency: !main_file.include?(php_package['name'])
+        )
         packages[package.package] = package
       end
+    end
+
+    private
+
+    def extract_composer_license(raw)
+      license = raw&.first
+      license = license&.tr('()', '  ')
+      license = license&.strip
+      license&.split&.first
     end
   end
 end

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 require 'nokogiri'
-require 'parallel'
 
-require_relative '../http_client'
-require_relative '../package'
+require_relative 'base'
 
 module SOUP
-  class GradleParser
+  class GradleParser < BaseParser
     REPOSITORY_URLS = %w[https://maven.google.com https://jcenter.bintray.com https://plugins.gradle.org/m2/ https://jitpack.io https://oss.sonatype.org/content/repositories/snapshots/ https://maven.pkg.github.com/skgmn/].freeze
     private_constant :REPOSITORY_URLS
 
@@ -34,12 +32,9 @@ module SOUP
           package_name.split(':')
         end
 
-      results =
-        Parallel.map(work_items, in_threads: HttpClient::THREAD_COUNT) do |group_id, artifact_id, version|
-          fetch_package(file, main_file, group_id, artifact_id, version)
-        end
-
-      results.compact.each { |package| packages[package.package] = package }
+      parallel_each(work_items, packages) do |group_id, artifact_id, version|
+        fetch_package(file, main_file, group_id, artifact_id, version)
+      end
     end
 
     private
@@ -75,15 +70,16 @@ module SOUP
         return
       end
 
-      package = Package.new("#{group_id}:#{artifact_id}")
-      package.file = file
-      package.language = 'Kotlin'
-      package.version = version
-      package.license = license
-      package.description = Package.sanitize_description(description)
-      package.website = website
-      package.dependency = !main_file.include?("#{group_id}:#{artifact_id}")
-      package
+      build_package(
+        name: "#{group_id}:#{artifact_id}",
+        file: file,
+        language: 'Kotlin',
+        version: version,
+        license: license,
+        description: Package.sanitize_description(description),
+        website: website,
+        dependency: !main_file.include?("#{group_id}:#{artifact_id}")
+      )
     end
   end
 end

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-require 'parallel'
-
-require_relative '../http_client'
-require_relative '../package'
+require_relative 'base'
 
 module SOUP
-  class NPMParser
+  class NPMParser < BaseParser
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
       main_file_json = JSON.parse(File.read(file.gsub('package-lock.json', 'package.json')))
@@ -16,12 +13,9 @@ module SOUP
 
       work_items = all_packages.reject { |key, value| key.empty? || value['dev'] }
 
-      results =
-        Parallel.map(work_items, in_threads: HttpClient::THREAD_COUNT) do |key, value|
-          fetch_package(file, direct_deps, key, value)
-        end
-
-      results.compact.each { |package| packages[package.package] = package }
+      parallel_each(work_items, packages) do |key, value|
+        fetch_package(file, direct_deps, key, value)
+      end
     end
 
     private
@@ -55,17 +49,19 @@ module SOUP
         return
       end
 
-      package = Package.new(name)
-      package.file = file
-      package.language = 'JS'
-      package.version = value['version']
       raw_license = package_details['license']
-      package.license = raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
-      package.license = 'NOASSERTION' if package.license.include?('Unlicense')
-      package.description = Package.sanitize_description(package_details['description'], strip_markdown: true)
-      package.website = package_details['homepage']
-      package.dependency = !direct_deps.include?(name)
-      package
+      license = raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
+
+      build_package(
+        name: name,
+        file: file,
+        language: 'JS',
+        version: value['version'],
+        license: license,
+        description: Package.sanitize_description(package_details['description'], strip_markdown: true),
+        website: package_details['homepage'],
+        dependency: !direct_deps.include?(name)
+      )
     end
   end
 end

--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'parallel'
 
-require_relative '../http_client'
-require_relative '../package'
+require_relative 'base'
 
 module SOUP
-  class PIPParser
+  class PIPParser < BaseParser
     def parse(file, packages)
       main_file =
         if File.exist?(file.gsub('.txt', '.in'))
@@ -30,12 +28,9 @@ module SOUP
         work_items << [pip_package, version]
       end
 
-      results =
-        Parallel.map(work_items, in_threads: HttpClient::THREAD_COUNT) do |pip_package, version|
-          fetch_package(file, main_file, pip_package, version)
-        end
-
-      results.compact.each { |package| packages[package.package] = package }
+      parallel_each(work_items, packages) do |pip_package, version|
+        fetch_package(file, main_file, pip_package, version)
+      end
     end
 
     private
@@ -47,27 +42,36 @@ module SOUP
       raise(response.message) unless response.code == 200
 
       package_details = JSON.parse(response.body)
-      package = Package.new(pip_package)
-      package.file = file
-      package.language = 'Python'
-      package.version = version
-      package.description = Package.sanitize_description(package_details['info']['summary'], first_sentence: true)
-      package.website = package_details['info']['home_page']&.strip
-      package.dependency = !main_file.include?(package.package)
+      info = package_details['info']
 
-      package_details['info']['classifiers'].each do |classifier|
-        if classifier.include?('License') and classifier.split('::').length > 2
-          classifier_license = classifier.split('::').last.strip.split("\n").first
-          package.license = "#{package.license} #{classifier_license}".strip
-        end
+      build_package(
+        name: pip_package,
+        file: file,
+        language: 'Python',
+        version: version,
+        license: extract_pip_license(info),
+        description: Package.sanitize_description(info['summary'], first_sentence: true),
+        website: info['home_page']&.strip,
+        dependency: !main_file.include?(pip_package)
+      )
+    end
+
+    def extract_pip_license(info)
+      license = ''
+
+      Array(info['classifiers']).each do |classifier|
+        next unless classifier.include?('License') && classifier.split('::').length > 2
+
+        classifier_license = classifier.split('::').last.strip.split("\n").first
+        license = "#{license} #{classifier_license}".strip
       end
 
-      if package.license.nil? or package.license.empty?
-        license = package_details['info']['license']&.strip&.split("\n")
-        package.license = license&.first
-      end
+      return license unless license.empty?
 
-      package
+      raw = info['license']
+      return raw if raw.nil?
+
+      raw.strip.split("\n").first
     end
   end
 end

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'parallel'
 
-require_relative '../http_client'
-require_relative '../package'
+require_relative 'base'
 
 module SOUP
-  class SPMParser
+  class SPMParser < BaseParser
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
       lock_file = lock_file['object'] if lock_file['object']
@@ -24,12 +22,9 @@ module SOUP
 
       token = ENV.fetch('GITHUB_TOKEN', '')
 
-      results =
-        Parallel.map(lock_file['pins'], in_threads: HttpClient::THREAD_COUNT) do |pin|
-          fetch_package(file, main_file, token, pin)
-        end
-
-      results.compact.each { |package| packages[package.package] = package }
+      parallel_each(lock_file['pins'], packages) do |pin|
+        fetch_package(file, main_file, token, pin)
+      end
     end
 
     private
@@ -54,15 +49,16 @@ module SOUP
 
       return if package_details['private']
 
-      package = Package.new(package_details['name'])
-      package.file = file
-      package.language = 'Swift'
-      package.version = pin['state']['version']&.strip
-      package.license = package_details.dig('license', 'spdx_id')&.strip
-      package.description = Package.sanitize_description(package_details['description'], first_sentence: true)
-      package.website = package_details['html_url']&.strip
-      package.dependency = !main_file.include?(package.package)
-      package
+      build_package(
+        name: package_details['name'],
+        file: file,
+        language: 'Swift',
+        version: pin['state']['version']&.strip,
+        license: package_details.dig('license', 'spdx_id')&.strip,
+        description: Package.sanitize_description(package_details['description'], first_sentence: true),
+        website: package_details['html_url']&.strip,
+        dependency: !main_file.include?(package_details['name'])
+      )
     end
   end
 end

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -1,25 +1,20 @@
 # frozen_string_literal: true
 
-require 'parallel'
 require 'yarn_lock_parser'
 
-require_relative '../http_client'
-require_relative '../package'
+require_relative 'base'
 
 module SOUP
-  class YarnParser
+  class YarnParser < BaseParser
     def parse(file, packages)
       lock_file = YarnLockParser::Parser.parse(file)
       main_file = File.read(file.gsub('yarn.lock', 'package.json'))
 
       work_items = lock_file.reject { |js_package| main_file.include?("#{js_package[:name]}\": \"file:vendor") }
 
-      results =
-        Parallel.map(work_items, in_threads: HttpClient::THREAD_COUNT) do |js_package|
-          fetch_package(file, main_file, js_package)
-        end
-
-      results.compact.each { |package| packages[package.package] = package }
+      parallel_each(work_items, packages) do |js_package|
+        fetch_package(file, main_file, js_package)
+      end
     end
 
     private
@@ -36,16 +31,17 @@ module SOUP
       raise(response.message) unless response.code == 200
 
       package_details = JSON.parse(response.body)['versions'][js_package[:version]]
-      package = Package.new(js_package[:name])
-      package.file = file
-      package.language = 'JS'
-      package.version = js_package[:version]
-      package.license = package_details['license']
-      package.license = 'NOASSERTION' if package.license&.include?('Unlicense')
-      package.description = Package.sanitize_description(package_details['description'], strip_markdown: true)
-      package.website = package_details['homepage']
-      package.dependency = !main_file.include?(js_package[:name])
-      package
+
+      build_package(
+        name: js_package[:name],
+        file: file,
+        language: 'JS',
+        version: js_package[:version],
+        license: package_details['license'],
+        description: Package.sanitize_description(package_details['description'], strip_markdown: true),
+        website: package_details['homepage'],
+        dependency: !main_file.include?(js_package[:name])
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

Addresses two findings from the recent code review (`docs/code-review.md`):

- **QUAL-001** — `Application#check_packages` had grown to ~83 lines, mixing license validation, cache merging, three near-identical interactive prompt blocks, sanitization, and markdown emission.
- **QUAL-003** — All 9 parsers re-implemented the same `Parallel.map → results.compact.each` orchestration scaffold and a duplicated `Package` factory tail, and the `Unlicense → NOASSERTION` normalization had drifted (applied in npm/yarn only, missing from bundler/pip/spm/gradle/composer).

Behavior is preserved end-to-end: all 125 specs pass, RuboCop clean, line coverage 97.03%, branch coverage 87.37%. License normalization is now consistent across every parser, so the previously-divergent `Unlicense` rule applies uniformly.

**Key changes:**

- Introduce `SOUP::BaseParser` (`lib/soup/parsers/base.rb`) owning the shared scaffold: `parallel_each` (Parallel.map + results merge), `build_package` (Package factory), and `normalize_license` (single source of truth for `Unlicense` / URL → `NOASSERTION`).
- Migrate `BundlerParser`, `ComposerParser`, `GradleParser`, `NPMParser`, `PIPParser`, `SPMParser`, `YarnParser` to inherit from `BaseParser`; remove duplicated `require 'parallel'` / `require_relative '../http_client'` / `require_relative '../package'` boilerplate.
- Extract `PIPParser#extract_pip_license` so the classifier-and-fallback assembly is a pure helper.
- Split `Application#check_packages` into focused helpers: `validate_license`, `apply_cached_metadata`, `apply_dependency_defaults`, `prompt_for_metadata`, `prompt_missing_field`, `ensure_metadata_complete!`, `append_markdown_row`.
- Replace the imperative `found = false` + `break` loop with `licenses.any? { ... }` inside the new `validate_license`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Pure refactor — existing 125 specs cover the touched surface area (parsers' public `parse` contract and `Application#execute` flow) and all pass unchanged.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified