### PR TITLE
Fix SPM path joining, composer optional keys, OptionParser rescue and CLI backtrace

### DIFF
--- a/bin/soup.rb
+++ b/bin/soup.rb
@@ -7,10 +7,18 @@ Encoding.default_internal = Encoding::UTF_8
 
 require_relative '../lib/soup/application'
 
+TOP_FRAMES_TO_SHOW = 5
+
 begin
   exit(SOUP::Application.new(ARGV).execute)
 rescue StandardError => e
   warn("Error: #{e.message}")
-  warn(e.backtrace.join("\n")) if ENV['DEBUG']
+  backtrace = Array(e.backtrace)
+  if ENV['DEBUG']
+    warn(backtrace.join("\n"))
+  elsif !backtrace.empty?
+    backtrace.first(TOP_FRAMES_TO_SHOW).each { |frame| warn("  #{frame}") }
+    warn('  ... (set DEBUG=1 for full backtrace)') if backtrace.length > TOP_FRAMES_TO_SHOW
+  end
   exit(1)
 end

--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -86,7 +86,7 @@ module SOUP
 
     def configure_options(argv)
       Options.new(argv).parse
-    rescue OptionParser::InvalidOption => e
+    rescue OptionParser::ParseError => e
       warn("Error: #{e}")
       exit(Status::ERROR_EXIT_CODE)
     end

--- a/lib/soup/parsers/composer.rb
+++ b/lib/soup/parsers/composer.rb
@@ -9,7 +9,7 @@ module SOUP
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
       main_file = File.read(file.gsub('lock', 'json'))
-      all_packages = lock_file['packages'] + lock_file['packages-dev']
+      all_packages = (lock_file['packages'] || []) + (lock_file['packages-dev'] || [])
 
       all_packages.each do |php_package|
         puts("Checking #{php_package['name']} #{php_package['version']}...")

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -9,14 +9,7 @@ module SOUP
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
       lock_file = lock_file['object'] if lock_file['object']
-      main_file =
-        if File.exist?(file.gsub('resolved', 'swift'))
-          File.read(file.gsub('resolved', 'swift'))
-        elsif File.exist?("#{file.split('Tuist').first}Tuist/Dependencies.swift")
-          File.read("#{file.split('Tuist').first}Tuist/Dependencies.swift")
-        elsif File.exist?("#{file.split('.').first}.xcodeproj/project.pbxproj")
-          File.read("#{file.split('.').first}.xcodeproj/project.pbxproj")
-        end
+      main_file = read_main_swift_file(file)
 
       raise('No main file found!') if main_file.nil?
 
@@ -28,6 +21,48 @@ module SOUP
     end
 
     private
+
+    # Locate the Swift manifest associated with a Package.resolved file.
+    # Tries, in order: the sibling Package.swift (or matching <Name>.swift),
+    # the enclosing Tuist/Dependencies.swift if the resolved file lives under a
+    # Tuist directory, and finally the sibling <Name>.xcodeproj/project.pbxproj.
+    # Path joining uses File.dirname + File.basename so directories containing
+    # dots in their name do not corrupt the candidate paths.
+    def read_main_swift_file(file)
+      dir = File.dirname(file)
+      base = File.basename(file, '.*')
+
+      package_swift = path_join(dir, "#{base}.swift")
+      return File.read(package_swift) if File.exist?(package_swift)
+
+      tuist_deps = tuist_dependencies_path(dir)
+      return File.read(tuist_deps) if tuist_deps && File.exist?(tuist_deps)
+
+      xcodeproj = path_join(dir, "#{base}.xcodeproj/project.pbxproj")
+      return File.read(xcodeproj) if File.exist?(xcodeproj)
+
+      nil
+    end
+
+    # Drop the leading "./" that File.join would introduce when dir == '.' so
+    # downstream File.exist?/File.read receive the same path callers use.
+    def path_join(dir, suffix)
+      return suffix if dir.nil? || dir.empty? || dir == '.'
+
+      "#{dir}/#{suffix}"
+    end
+
+    # If the resolved file lives anywhere inside a Tuist/ directory, return the
+    # path to Dependencies.swift inside that same Tuist directory. Returns nil
+    # otherwise so a non-Tuist project never invents a synthetic path.
+    def tuist_dependencies_path(dir)
+      parts = dir.split('/')
+      tuist_idx = parts.index('Tuist')
+      return if tuist_idx.nil?
+
+      tuist_root = parts[0..tuist_idx].join('/')
+      "#{tuist_root}/Dependencies.swift"
+    end
 
     def fetch_package(file, main_file, token, pin)
       pin_id = pin['identity'] || pin['package']

--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -143,6 +143,18 @@ RSpec.describe(SOUP::Application) do
       expect(exit_code).to(eq(SOUP::Status::SUCCESS_EXIT_CODE))
     end
 
+    context 'when CLI args trigger an OptionParser::ParseError subclass other than InvalidOption' do
+      # Regression test for BUG-017: the configure_options rescue used to be
+      # OptionParser::InvalidOption only, which let MissingArgument (and other
+      # ParseError subclasses) escape with a stack trace instead of the
+      # friendly "Error: ..." message + ERROR_EXIT_CODE.
+      it 'exits with ERROR_EXIT_CODE on --licenses_file missing its required argument', :aggregate_failures do
+        expect { described_class.new(['--licenses_file']) }
+          .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(SOUP::Status::ERROR_EXIT_CODE)) }
+                .and(output(/missing argument/).to_stderr))
+      end
+    end
+
     context 'when config file is missing' do
       def missing_licenses_args
         ['--licenses', '--licenses_file', '/nonexistent/path.json', '--exceptions_file', exceptions_file.path] + skip_all_parsers

--- a/spec/soup/composer_parser_spec.rb
+++ b/spec/soup/composer_parser_spec.rb
@@ -112,6 +112,51 @@ RSpec.describe(SOUP::ComposerParser) do
     end
   end
 
+  context 'with composer.lock missing packages-dev key' do
+    # Regression test for BUG-021: production-only lockfiles (e.g. from
+    # composer install --no-dev) may omit packages-dev entirely. The parser
+    # used to raise TypeError on Array + nil.
+    let(:lock_file) do
+      {
+        packages: [
+          {
+            name: 'vendor/prod-only',
+            version: '1.0.0',
+            license: ['MIT'],
+            description: 'Prod',
+            homepage: 'https://example.com'
+          }
+        ]
+      }.to_json
+    end
+
+    it 'treats missing packages-dev as empty and parses the prod packages', :aggregate_failures do
+      expect { packages }
+        .not_to(raise_error)
+      expect(packages).to(have_key('vendor/prod-only'))
+    end
+  end
+
+  context 'with composer.lock missing packages key' do
+    let(:lock_file) do
+      {
+        'packages-dev': [
+          {
+            name: 'vendor/dev-only',
+            version: '1.0.0',
+            license: ['MIT'],
+            description: 'Dev',
+            homepage: 'https://example.com'
+          }
+        ]
+      }.to_json
+    end
+
+    it 'treats missing packages as empty and still parses dev packages' do
+      expect(packages).to(have_key('vendor/dev-only'))
+    end
+  end
+
   context 'with URL license' do
     let(:lock_file) do
       {

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -180,7 +180,6 @@ RSpec.describe(SOUP::SPMParser) do
   context 'when only xcodeproj exists' do
     before do
       allow(File).to(receive(:exist?).with('Package.swift').and_return(false))
-      allow(File).to(receive(:exist?).with('Package.resolvedTuist/Dependencies.swift').and_return(false))
       allow(File).to(receive(:exist?).with('Package.xcodeproj/project.pbxproj').and_return(true))
       allow(File).to(receive(:read).with('Package.xcodeproj/project.pbxproj').and_return(main_file_content))
       stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
@@ -194,10 +193,30 @@ RSpec.describe(SOUP::SPMParser) do
     end
   end
 
+  context 'when the project directory contains a dot in its name' do
+    # Regression test for BUG-011: a previous implementation used
+    # file.split('.').first to derive the xcodeproj path, which truncated
+    # any path whose parent directory contained a dot.
+    before do
+      allow(File).to(receive(:read).with('/Users/foo.bar/MyProject/Package.resolved').and_return(resolved_file))
+      allow(File).to(receive(:exist?).with('/Users/foo.bar/MyProject/Package.swift').and_return(false))
+      allow(File).to(receive(:exist?).with('/Users/foo.bar/MyProject/Package.xcodeproj/project.pbxproj').and_return(true))
+      allow(File).to(receive(:read).with('/Users/foo.bar/MyProject/Package.xcodeproj/project.pbxproj').and_return(main_file_content))
+      stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
+        .to_return(status: 200, body: github_response)
+    end
+
+    it 'resolves the xcodeproj sibling path without truncating at the first dot', :aggregate_failures do
+      packages = {}
+      expect { parser.parse('/Users/foo.bar/MyProject/Package.resolved', packages) }
+        .not_to(raise_error)
+      expect(packages).to(have_key('Alamofire'))
+    end
+  end
+
   context 'when no main file exists' do
     before do
       allow(File).to(receive(:exist?).with('Package.swift').and_return(false))
-      allow(File).to(receive(:exist?).with('Package.resolvedTuist/Dependencies.swift').and_return(false))
       allow(File).to(receive(:exist?).with('Package.xcodeproj/project.pbxproj').and_return(false))
     end
 


### PR DESCRIPTION
## Summary

Closes the 5 remaining Medium findings from `docs/code-review.md` in a single PR. Each fix is small and low-risk; bundling them avoids 5 separate review/CI cycles.

Behavior preserved end-to-end: 136 RSpec examples pass (up from 132 — 4 new regression tests), RuboCop clean, line coverage 97.69%, branch coverage 86.57%.

**Key changes:**

- **BUG-011 + TEST-005** — `lib/soup/parsers/spm.rb`, `spec/soup/spm_parser_spec.rb`: Replace fragile `file.split('.').first` / `file.split('Tuist').first` heuristics with explicit `File.dirname` + `File.basename(file, '.*')` resolution. Extract `read_main_swift_file`, `path_join`, and `tuist_dependencies_path` helpers. The previous `spm_parser_spec.rb:183` test that stubbed the buggy `Package.resolvedTuist/Dependencies.swift` artifact is removed, and a new regression test covers a project path that contains a dot in a parent directory (e.g., `/Users/foo.bar/MyProject/Package.resolved`).
- **BUG-017** — `lib/soup/application.rb`: Broaden `rescue OptionParser::InvalidOption` to `OptionParser::ParseError` so sibling subclasses (`MissingArgument`, `InvalidArgument`, `AmbiguousOption`, `NeedlessArgument`) get the friendly `Error: ...` message + `ERROR_EXIT_CODE` instead of escaping with a stack trace. New regression test in `spec/soup/application_spec.rb` exercises the `--licenses_file` (no value) path.
- **BUG-018** — `bin/soup.rb`: Print the top 5 stack frames unconditionally to STDERR on uncaught errors and include a `... (set DEBUG=1 for full backtrace)` hint, instead of hiding the entire backtrace behind an undocumented env var. Full backtrace still available with `DEBUG=1`.
- **BUG-021** — `lib/soup/parsers/composer.rb`: Guard against missing `packages` and `packages-dev` keys with `(... || [])`. Production-only lockfiles (`composer install --no-dev`) no longer crash with `TypeError: no implicit conversion of nil into Array`. Two new regression tests in `spec/soup/composer_parser_spec.rb` cover missing-`packages-dev` and missing-`packages` lockfiles.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified