### PR TITLE
Add malformed-lockfile regression specs for five parsers (TEST-04)

### DIFF
--- a/spec/soup/bundler_parser_spec.rb
+++ b/spec/soup/bundler_parser_spec.rb
@@ -116,4 +116,40 @@ RSpec.describe(SOUP::BundlerParser) do
       expect(packages['test-gem'].dependency).to(be(true))
     end
   end
+
+  # TEST-04: malformed-lockfile coverage. Locks in current behavior so future
+  # error-handling improvements are deliberate, not accidental.
+  describe '#parse with malformed input' do
+    let(:packages) { {} }
+
+    before do
+      # Override the top-level stub so the parser's Bundler::LockfileParser.new
+      # actually runs against the test content rather than the instance_double.
+      allow(Bundler::LockfileParser).to(receive(:new).and_call_original)
+    end
+
+    context 'with an empty Gemfile.lock' do
+      before do
+        allow(Bundler).to(receive(:read_file).with('Gemfile.lock').and_return(''))
+      end
+
+      it 'parses without raising and adds no packages', :aggregate_failures do
+        expect { parser.parse('Gemfile.lock', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+      end
+    end
+
+    context 'with garbage content that yields no specs' do
+      before do
+        allow(Bundler).to(receive(:read_file).with('Gemfile.lock').and_return("not a lockfile\n"))
+      end
+
+      it 'parses without raising and adds no packages', :aggregate_failures do
+        expect { parser.parse('Gemfile.lock', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+      end
+    end
+  end
 end

--- a/spec/soup/composer_parser_spec.rb
+++ b/spec/soup/composer_parser_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe(SOUP::ComposerParser) do
 
   let(:packages) { {} }
 
-  before do
+  before do |example|
     allow(File).to(receive(:read).and_call_original)
     allow(File).to(receive(:read).with('composer.lock').and_return(lock_file))
     allow(File).to(receive(:read).with('composer.json').and_return(main_file))
-    parser.parse('composer.lock', packages)
+    parser.parse('composer.lock', packages) if example.metadata.fetch(:auto_parse, true)
   end
 
   it 'parses packages and packages-dev', :aggregate_failures do
@@ -157,6 +157,25 @@ RSpec.describe(SOUP::ComposerParser) do
     end
   end
 
+  # TEST-04: graceful malformed-lockfile cases. Structurally-empty and
+  # unknown-shape JSON should fall through the existing `|| []` guards
+  # without raising.
+  context 'with structurally empty (but valid JSON) composer.lock' do
+    let(:lock_file) { '{}' }
+
+    it 'parses without raising and adds no packages' do
+      expect(packages).to(be_empty)
+    end
+  end
+
+  context 'with composer.lock that lacks both packages and packages-dev keys' do
+    let(:lock_file) { '{"foo": "bar"}' }
+
+    it 'parses without raising and adds no packages' do
+      expect(packages).to(be_empty)
+    end
+  end
+
   context 'with URL license' do
     let(:lock_file) do
       {
@@ -175,6 +194,36 @@ RSpec.describe(SOUP::ComposerParser) do
 
     it 'converts URL license to NOASSERTION' do
       expect(packages['vendor/url-pkg'].license).to(eq('NOASSERTION'))
+    end
+  end
+
+  # TEST-04: malformed-JSON cases use auto_parse: false so the top-level
+  # before-hook does not invoke parser.parse before the example body has
+  # a chance to assert on the expected exception.
+  context 'with malformed composer.lock JSON', auto_parse: false do
+    let(:lock_file) { 'not json' }
+
+    it 'raises JSON::ParserError on non-JSON garbage' do
+      expect { parser.parse('composer.lock', packages) }
+        .to(raise_error(JSON::ParserError))
+    end
+
+    context 'with empty composer.lock content' do
+      let(:lock_file) { '' }
+
+      it 'raises JSON::ParserError' do
+        expect { parser.parse('composer.lock', packages) }
+          .to(raise_error(JSON::ParserError))
+      end
+    end
+
+    context 'with truncated JSON in composer.lock' do
+      let(:lock_file) { '{"packages":[{"name":"vendor/x"' }
+
+      it 'raises JSON::ParserError' do
+        expect { parser.parse('composer.lock', packages) }
+          .to(raise_error(JSON::ParserError))
+      end
     end
   end
 end

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -255,4 +255,57 @@ RSpec.describe(SOUP::GradleParser) do
       expect(packages['androidx.activity:activity-compose'].dependency).to(be(false))
     end
   end
+
+  # TEST-04: malformed-lockfile coverage. The gradle lockfile is a plain
+  # text format; the parser tolerates empty input and comment-only files,
+  # and skips lines that don't have a key=value shape.
+  describe '#parse with malformed input' do
+    let(:packages) { {} }
+
+    before do
+      allow(File).to(receive(:read).and_call_original)
+      allow(File).to(receive(:read).with('build.gradle').and_return("dependencies {}\n"))
+      allow(File).to(receive(:read).with('build.gradle.kts').and_raise(Errno::ENOENT))
+    end
+
+    context 'with an empty gradle.lockfile' do
+      before do
+        allow(File).to(receive(:readlines).with('buildscript-gradle.lockfile').and_return([]))
+      end
+
+      it 'parses without raising and adds no packages', :aggregate_failures do
+        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+      end
+    end
+
+    context 'with a comment-only gradle.lockfile' do
+      let(:lines) { ["# This is a Gradle generated file\n", "# Do not edit\n"] }
+
+      before do
+        allow(File).to(receive(:readlines).with('buildscript-gradle.lockfile').and_return(lines))
+      end
+
+      it 'parses without raising and adds no packages', :aggregate_failures do
+        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+      end
+    end
+
+    context 'with malformed lines missing the = separator' do
+      let(:lines) { ["garbage line without equals\n", "another garbage line\n"] }
+
+      before do
+        allow(File).to(receive(:readlines).with('buildscript-gradle.lockfile').and_return(lines))
+      end
+
+      it 'parses without raising and adds no packages (silently skipped)', :aggregate_failures do
+        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+      end
+    end
+  end
 end

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -192,4 +192,42 @@ RSpec.describe(SOUP::PIPParser) do
       expect(packages['pkg'].license).to(be_nil)
     end
   end
+
+  # TEST-04: malformed-input coverage. requirements.txt is a plain text format;
+  # the parser skips blank/comment lines and raises on lines with loose
+  # constraints (covered in the existing "loose constraints" context).
+  describe '#parse with malformed input' do
+    let(:packages) { {} }
+
+    before do
+      allow(File).to(receive(:exist?).and_call_original)
+      allow(File).to(receive(:exist?).with('requirements.in').and_return(false))
+    end
+
+    context 'with an empty requirements.txt' do
+      before do
+        allow(File).to(receive(:foreach).with('requirements.txt'))
+      end
+
+      it 'parses without raising and adds no packages', :aggregate_failures do
+        expect { parser.parse('requirements.txt', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+      end
+    end
+
+    context 'with a comment-and-blank-line-only requirements.txt' do
+      before do
+        ["# header comment\n", "\n", "  \n", "# another comment\n"].each do |line|
+          allow(File).to(receive(:foreach).with('requirements.txt').and_yield(line))
+        end
+      end
+
+      it 'parses without raising and adds no packages', :aggregate_failures do
+        expect { parser.parse('requirements.txt', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+      end
+    end
+  end
 end

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -328,4 +328,47 @@ RSpec.describe(SOUP::SPMParser) do
         .to(raise_error(/Bad credentials/))
     end
   end
+
+  # TEST-04: malformed-Package.resolved coverage. Locks in current behavior
+  # so future error-handling improvements are deliberate, not accidental.
+  describe '#parse with malformed input' do
+    let(:packages) { {} }
+
+    context 'with empty Package.resolved content' do
+      before { allow(File).to(receive(:read).with('Package.resolved').and_return('')) }
+
+      it 'raises JSON::ParserError' do
+        expect { parser.parse('Package.resolved', packages) }
+          .to(raise_error(JSON::ParserError))
+      end
+    end
+
+    context 'with truncated JSON in Package.resolved' do
+      before { allow(File).to(receive(:read).with('Package.resolved').and_return('{"pins":[{"identity":"alamofire"')) }
+
+      it 'raises JSON::ParserError' do
+        expect { parser.parse('Package.resolved', packages) }
+          .to(raise_error(JSON::ParserError))
+      end
+    end
+
+    context 'with non-JSON garbage in Package.resolved' do
+      before { allow(File).to(receive(:read).with('Package.resolved').and_return('not json')) }
+
+      it 'raises JSON::ParserError' do
+        expect { parser.parse('Package.resolved', packages) }
+          .to(raise_error(JSON::ParserError))
+      end
+    end
+
+    context 'with valid JSON but empty pins array' do
+      before { allow(File).to(receive(:read).with('Package.resolved').and_return('{"pins":[]}')) }
+
+      it 'parses without raising and adds no packages', :aggregate_failures do
+        expect { parser.parse('Package.resolved', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Addresses TEST-04 from `docs/code-review.md`: the audit found that no parser spec covered malformed lockfile inputs. These specs lock in current behavior so future error-handling improvements are deliberate, not accidental. Tests-only PR — no production code is touched.

Yarn and npm are intentionally out of scope here: their primary malformed-input case (Yarn Berry / npm v1 `lockfileVersion`) is already covered by the BUG-01 and BUG-02 regression specs in PR #329.

**Key changes:**

- `spec/soup/bundler_parser_spec.rb` — new `describe '#parse with malformed input'` block covering empty `Gemfile.lock` content and garbage non-lockfile content. Both parse without raising and produce zero packages (Bundler::LockfileParser handles silently).
- `spec/soup/composer_parser_spec.rb` — small refactor of the top-level `before` to honor `auto_parse: false` metadata so raise-cases can opt out of the auto-parse. Two new graceful-no-op contexts (empty `{}` and unknown-shape JSON) verify the existing `|| []` guards. A new `with malformed composer.lock JSON` outer context (`auto_parse: false`) covers empty / truncated / non-JSON content, all asserting `JSON::ParserError`.
- `spec/soup/gradle_parser_spec.rb` — new `describe '#parse with malformed input'` block covering empty, comment-only, and missing-`=` lines. All parse to zero packages.
- `spec/soup/pip_parser_spec.rb` — new `describe '#parse with malformed input'` block covering empty `requirements.txt` and comment-and-blank-line-only content. Both parse to zero packages.
- `spec/soup/spm_parser_spec.rb` — new `describe '#parse with malformed input'` block covering empty / truncated / non-JSON `Package.resolved` (all `JSON::ParserError`) plus valid JSON with `pins: []` (parses to zero packages, no network).

Full RSpec suite: 152 examples, 0 failures, line coverage 97.69%, branch coverage 86.57%. RuboCop clean on touched files.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): test-only addition — malformed-input regression specs

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified