### PR TITLE
Tighten npm/spm/gradle error handling: crash guards + http_error_message

### DIFF
--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -58,7 +58,8 @@ module SOUP
 
     def fetch_package(file, main_file, group_id, artifact_id, version)
       puts("Checking #{group_id}:#{artifact_id} #{version}...")
-      response = HttpClient.get("https://search.maven.org/solrsearch/select?q=g:%22#{group_id}%22+AND+a:%22#{artifact_id}%22+AND+v:%22#{version}%22&rows=1&wt=json")
+      last_url = "https://search.maven.org/solrsearch/select?q=g:%22#{group_id}%22+AND+a:%22#{artifact_id}%22+AND+v:%22#{version}%22&rows=1&wt=json"
+      response = HttpClient.get(last_url)
 
       parsed = JSON.parse(response.body) if response.code == 200
       docs = parsed&.dig('response', 'docs')
@@ -69,7 +70,8 @@ module SOUP
         website = docs[0]['home_page']
       else
         REPOSITORY_URLS.each do |url|
-          response = HttpClient.get("#{url}/#{group_id.tr('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom")
+          last_url = "#{url}/#{group_id.tr('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom"
+          response = HttpClient.get(last_url)
 
           next unless response.code == 200
 
@@ -83,7 +85,7 @@ module SOUP
       end
 
       if response.code != 200
-        warn("Could not find #{group_id}:#{artifact_id} #{version}...")
+        warn(http_error_message(response, url: last_url, package: "#{group_id}:#{artifact_id} #{version}"))
         return
       end
 

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -9,7 +9,8 @@ module SOUP
       main_file_json = JSON.parse(File.read(file.gsub('package-lock.json', 'package.json')))
       direct_deps = (main_file_json['dependencies'] || {}).keys |
                     (main_file_json['devDependencies'] || {}).keys
-      all_packages = lock_file['packages']
+      all_packages = lock_file['packages'] ||
+                     raise("Unsupported package-lock.json at #{file}: lockfileVersion 2+ (with 'packages' key) is required")
 
       work_items = all_packages.reject { |key, value| key.empty? || value['dev'] }
 

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -78,9 +78,14 @@ module SOUP
           HttpClient.get(url, headers: { Authorization: "token #{token}" })
         end
 
-      raise("Error: #{response.message}! Please set GITHUB_TOKEN.") if response.message.include?('rate limit') || response.message.include?('Bad credentials')
+      unless response.code == 200
+        combined = github_error_message(response)
+        raise('GitHub API: rate limit exceeded. Please set GITHUB_TOKEN to raise the rate limit.') if combined.include?('rate limit')
+        raise('GitHub API: Bad credentials. Please verify GITHUB_TOKEN.') if combined.downcase.include?('bad credentials')
 
-      return unless response.code == 200
+        warn(http_error_message(response, url: url, package: pin_id))
+        return
+      end
 
       package_details = JSON.parse(response.body)
 
@@ -106,6 +111,22 @@ module SOUP
       state = pin['state'] || {}
       raw = state['version'] || state['branch'] || state['revision']
       raw&.to_s&.strip
+    end
+
+    # GitHub returns its actionable error string ("API rate limit exceeded...",
+    # "Bad credentials") in the JSON response body's `message` field, NOT in
+    # the HTTP reason phrase. We still concatenate the reason phrase so any
+    # consumer that already relies on it keeps working.
+    def github_error_message(response)
+      body_message =
+        begin
+          parsed = JSON.parse(response.body.to_s)
+          parsed.is_a?(Hash) ? parsed['message'].to_s : ''
+        rescue JSON::ParserError
+          ''
+        end
+
+      [body_message, response.message.to_s].reject(&:empty?).join(' ')
     end
   end
 end

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -158,6 +158,28 @@ RSpec.describe(SOUP::GradleParser) do
         expect(packages).to(have_key('com.example:library'))
       end
     end
+
+    context 'when every fallback repository returns a non-200' do
+      # Regression test for BUG-07: the warn used to be a one-liner that
+      # dropped the URL, HTTP status, and response body, making maven-side
+      # failures opaque. It now uses BaseParser#http_error_message so the
+      # operator sees status + url + truncated body.
+      before do
+        stub_request(:get, /maven\.google\.com/).to_return(status: 503, body: 'maven.google: gateway timeout')
+        stub_request(:get, /jcenter\.bintray\.com/).to_return(status: 503, body: 'jcenter offline')
+        stub_request(:get, /plugins\.gradle\.org/).to_return(status: 503, body: 'plugins offline')
+        stub_request(:get, /jitpack\.io/).to_return(status: 503, body: 'jitpack offline')
+        stub_request(:get, /oss\.sonatype\.org/).to_return(status: 503, body: 'sonatype offline')
+        stub_request(:get, /maven\.pkg\.github\.com/).to_return(status: 503, body: 'ghcr offline')
+      end
+
+      it 'warns with http_error_message (status, url, package, truncated body)', :aggregate_failures do
+        packages = {}
+        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+          .to(output(/HTTP 503.*com\.example:library 1\.0\.0.*\.pom.*offline/m).to_stderr)
+        expect(packages).to(be_empty)
+      end
+    end
   end
 
   context 'when package is not in main file' do

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -175,4 +175,19 @@ RSpec.describe(SOUP::NPMParser) do
       expect(packages['transitive-only'].dependency).to(be(true))
     end
   end
+
+  context 'with a lockfileVersion 1 package-lock.json (no `packages` key)' do
+    # Regression test for BUG-02: npm v6 / lockfileVersion 1 lockfiles only
+    # contain a top-level `dependencies` key; without the nil guard in
+    # npm.rb#parse the next line raises NoMethodError on NilClass and the
+    # whole run aborts.
+    let(:lock_file) { { dependencies: { lodash: { version: '4.17.21' } } }.to_json }
+
+    it 'raises a clear unsupported-format error', :aggregate_failures do
+      packages = {}
+      expect { parser.parse('package-lock.json', packages) }
+        .to(raise_error(/Unsupported package-lock\.json/))
+      expect(packages).to(be_empty)
+    end
+  end
 end

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -265,6 +265,44 @@ RSpec.describe(SOUP::SPMParser) do
     end
   end
 
+  context 'when rate limited with the real GitHub response shape' do
+    # Regression test for BUG-05: GitHub returns the actionable string in the
+    # response BODY (the `message` field), not in the HTTP reason phrase.
+    # Pre-fix the parser only inspected `response.message` (reason phrase) so
+    # this realistic 403 fell through to a silent return.
+    before do
+      stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
+        .to_return(
+          status: [403, 'Forbidden'],
+          body: { message: 'API rate limit exceeded for 1.2.3.4', documentation_url: '...' }.to_json
+        )
+    end
+
+    it 'raises on rate limit even when the reason phrase does not contain the keyword' do
+      packages = {}
+      expect { parser.parse('Package.resolved', packages) }
+        .to(raise_error(/rate limit/))
+    end
+  end
+
+  context 'when GitHub returns a 5xx error' do
+    # Regression test for BUG-06: the parser used to silently `return unless
+    # response.code == 200` on non-200 responses, omitting the package from
+    # the SOUP report with no diagnostic. It should warn via http_error_message
+    # to match the discipline of every other parser post-PR #327.
+    before do
+      stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
+        .to_return(status: [502, 'Bad Gateway'], body: '<html>upstream timeout</html>')
+    end
+
+    it 'warns with status + url + package context and omits the package', :aggregate_failures do
+      packages = {}
+      expect { parser.parse('Package.resolved', packages) }
+        .to(output(%r{HTTP 502 .*package=alamofire.*url=https://api\.github\.com/repos/Alamofire/Alamofire.*body=<html>upstream timeout</html>}m).to_stderr)
+      expect(packages).to(be_empty)
+    end
+  end
+
   context 'when pin is branch-based (no version)' do
     let(:resolved_file) do
       {


### PR DESCRIPTION
## Summary

Four error-handling cluster fixes from `docs/code-review.md`. Bundled into one PR because the spm.rb and gradle.rb changes both apply the `http_error_message` discipline established by PR #327, and BUG-02 mirrors the BUG-01 fix already shipped in #329.

**Key changes:**

- `lib/soup/parsers/npm.rb` — BUG-02 (HIGH). `lock_file['packages']` is `nil` on lockfileVersion 1 lockfiles (npm v6 and earlier); the next line called `.reject` on `nil` and crashed the whole run with `NoMethodError`. Now raises `"Unsupported package-lock.json at <file>: lockfileVersion 2+ (with 'packages' key) is required"`.
- `lib/soup/parsers/spm.rb` — BUG-05 (MEDIUM) + BUG-06 (MEDIUM). The rate-limit / bad-credentials detection used to inspect `response.message` (the HTTP reason phrase) but GitHub returns those strings in the response body's `message` field, so real-world 403s fell through to a silent `return`. Added a `github_error_message` helper that parses the body and concatenates the reason phrase, so detection now fires on the realistic `status: 403, body: {"message":"API rate limit exceeded..."}` shape AND keeps the existing WebMock-style tests green. After the rate-limit/bad-creds raise, the non-200 path now falls through to `warn(http_error_message(response, url: url, package: pin_id))` so 5xx hits surface like every other parser post-PR #327 instead of silently dropping the package.
- `lib/soup/parsers/gradle.rb` — BUG-07 (MEDIUM). The non-200 warn was a one-liner that dropped the URL, HTTP status, and response body. Captured the last attempted URL into a `last_url` local across the Maven Central search + 6-mirror POM fallback, then replaced the warn with `warn(http_error_message(response, url: last_url, package: "<g>:<a> <v>"))` so the operator sees status + url + package + truncated body.
- `spec/soup/npm_parser_spec.rb` — new `with a lockfileVersion 1 package-lock.json (no 'packages' key)` regression context for BUG-02. Mirrors the BUG-01 yarn regression spec.
- `spec/soup/spm_parser_spec.rb` — new `when rate limited with the real GitHub response shape` context (BUG-05) stubbing `status: [403, 'Forbidden'], body: {"message":"API rate limit exceeded..."}`. New `when GitHub returns a 5xx error` context (BUG-06) asserting the stderr output contains `HTTP 502 ... package=alamofire ... url=https://api.github.com/... ... body=<html>upstream timeout</html>`.
- `spec/soup/gradle_parser_spec.rb` — new `when every fallback repository returns a non-200` context (BUG-07) stubbing all six mirrors to 503 with bodies and asserting the stderr warn now includes `HTTP 503`, the package coordinate, the `.pom` URL, and the body content.

Full RSpec suite: 158 examples, 0 failures, line coverage 98.09%, branch coverage 86.94%. RuboCop clean on touched files.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified