### PR TITLE
Medium cluster A: sibling-file helper, license String tolerance, env timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ options
 | Variable                | Required | Description                                                                                                                                                                                     |
 |-------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `GITHUB_TOKEN`          | Optional | GitHub personal access token for SPM dependency lookups. Required when processing many Swift packages to avoid GitHub API rate limiting. [Create one here](https://github.com/settings/tokens). |
-| `SOUP_HTTP_TIMEOUT`     | Optional | Per-request HTTP timeout in seconds (integer). Defaults to `5`. Raise this on slow corporate proxies or rate-limited mirrors.                                                                  |
-| `SOUP_HTTP_MAX_RETRIES` | Optional | Number of retries on transient timeouts (integer). Defaults to `3`. Each retry uses the same timeout.                                                                                          |
+| `SOUP_HTTP_TIMEOUT`     | Optional | Per-request HTTP timeout in seconds (integer). Defaults to `5`. Raise this on slow corporate proxies or rate-limited mirrors.                                                                   |
+| `SOUP_HTTP_MAX_RETRIES` | Optional | Number of retries on transient timeouts (integer). Defaults to `3`. Each retry uses the same timeout.                                                                                           |
 
 The tool works without `GITHUB_TOKEN` for non-SPM projects. When processing SPM dependencies, unauthenticated GitHub
 API requests are limited to 60 per hour. Setting `GITHUB_TOKEN` increases this to 5,000 per hour.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ You can use the [Docker images](https://hub.docker.com/r/ydesgagne/ci-tools).
 
 Run `soup` in the root of the project.
 
+Running `soup` with no flags is equivalent to `soup --licenses --soup` — both
+license compliance checking and SOUP file generation are enabled by default.
+Pass `--licenses` alone (or `--soup` alone) to opt into a single mode.
+
 ```bash
 Usage: soup options
 
@@ -84,9 +88,11 @@ options
 
 ### Environment Variables
 
-| Variable       | Required | Description                                                                                                                                                                                     |
-|----------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `GITHUB_TOKEN` | Optional | GitHub personal access token for SPM dependency lookups. Required when processing many Swift packages to avoid GitHub API rate limiting. [Create one here](https://github.com/settings/tokens). |
+| Variable                | Required | Description                                                                                                                                                                                     |
+|-------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `GITHUB_TOKEN`          | Optional | GitHub personal access token for SPM dependency lookups. Required when processing many Swift packages to avoid GitHub API rate limiting. [Create one here](https://github.com/settings/tokens). |
+| `SOUP_HTTP_TIMEOUT`     | Optional | Per-request HTTP timeout in seconds (integer). Defaults to `5`. Raise this on slow corporate proxies or rate-limited mirrors.                                                                  |
+| `SOUP_HTTP_MAX_RETRIES` | Optional | Number of retries on transient timeouts (integer). Defaults to `3`. Each retry uses the same timeout.                                                                                          |
 
 The tool works without `GITHUB_TOKEN` for non-SPM projects. When processing SPM dependencies, unauthenticated GitHub
 API requests are limited to 60 per hour. Setting `GITHUB_TOKEN` increases this to 5,000 per hour.

--- a/lib/soup/http_client.rb
+++ b/lib/soup/http_client.rb
@@ -5,19 +5,32 @@ require 'httparty'
 
 module SOUP
   module HttpClient
-    MAX_RETRIES = 3
-    DEFAULT_TIMEOUT = 5
+    # Defaults are tuned for healthy public package registries (rubygems,
+    # registry.npmjs, pypi, search.maven, api.github). Override at runtime
+    # via SOUP_HTTP_TIMEOUT (seconds, integer) and SOUP_HTTP_MAX_RETRIES
+    # (integer) for slow corporate proxies, rate-limited mirrors, or
+    # air-gapped environments.
+    DEFAULT_MAX_RETRIES = 3
+    DEFAULT_TIMEOUT_SECONDS = 5
     THREAD_COUNT = Etc.nprocessors
 
-    private_constant :MAX_RETRIES
-    private_constant :DEFAULT_TIMEOUT
+    private_constant :DEFAULT_MAX_RETRIES, :DEFAULT_TIMEOUT_SECONDS
     public_constant :THREAD_COUNT
 
-    def self.get(url, max_retries: MAX_RETRIES, **options)
+    def self.max_retries
+      Integer(ENV.fetch('SOUP_HTTP_MAX_RETRIES', DEFAULT_MAX_RETRIES))
+    end
+
+    def self.default_timeout
+      Integer(ENV.fetch('SOUP_HTTP_TIMEOUT', DEFAULT_TIMEOUT_SECONDS))
+    end
+
+    def self.get(url, max_retries: nil, **options)
+      max_retries ||= self.max_retries
       retries = 0
 
       begin
-        HTTParty.get(url, { timeout: DEFAULT_TIMEOUT }.merge(options))
+        HTTParty.get(url, { timeout: default_timeout }.merge(options))
       rescue Net::OpenTimeout, Net::ReadTimeout => e
         retries += 1
 

--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -49,6 +49,19 @@ module SOUP
       license
     end
 
+    # Return the path of a sibling file next to `file` (in the same directory).
+    # Uses dirname/basename so a path containing the substring of the lockfile
+    # name (e.g. /Users/blocker/composer.lock) is not corrupted, and preserves
+    # the caller's "relative or absolute" shape: a bare 'composer.lock' yields
+    # 'composer.json' (not './composer.json') so File.read stubs and callers
+    # that pass bare basenames keep working.
+    def sibling_file(file, suffix)
+      dir = File.dirname(file)
+      return suffix if dir.nil? || dir.empty? || dir == '.'
+
+      File.join(dir, suffix)
+    end
+
     # Build an actionable error message for a non-2xx response.
     #
     # Includes status code, reason phrase, URL, the package being processed (when

--- a/lib/soup/parsers/composer.rb
+++ b/lib/soup/parsers/composer.rb
@@ -8,7 +8,7 @@ module SOUP
   class ComposerParser < BaseParser
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
-      main_file = File.read(file.gsub('lock', 'json'))
+      main_file = File.read(sibling_file(file, 'composer.json'))
       all_packages = (lock_file['packages'] || []) + (lock_file['packages-dev'] || [])
 
       all_packages.each do |php_package|
@@ -30,8 +30,13 @@ module SOUP
 
     private
 
+    # Composer schema permits `license` to be a single string (e.g. "MIT") or an
+    # Array of SPDX-style strings (for disjunctive 'OR' combinations). Wrap with
+    # Array() so a String input behaves the same as a single-element Array
+    # instead of crashing on .first (plain Ruby) or returning the first char
+    # (when ActiveSupport's String#first is loaded).
     def extract_composer_license(raw)
-      license = raw&.first
+      license = Array(raw).first
       license = license&.tr('()', '  ')
       license = license&.strip
       license&.split&.first

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -6,7 +6,7 @@ module SOUP
   class NPMParser < BaseParser
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
-      main_file_json = JSON.parse(File.read(file.gsub('package-lock.json', 'package.json')))
+      main_file_json = JSON.parse(File.read(sibling_file(file, 'package.json')))
       direct_deps = (main_file_json['dependencies'] || {}).keys |
                     (main_file_json['devDependencies'] || {}).keys
       all_packages = lock_file['packages'] ||

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -9,7 +9,7 @@ module SOUP
     def parse(file, packages)
       lock_file = YarnLockParser::Parser.parse(file) ||
                   raise("Unsupported yarn.lock format at #{file}: only Yarn v1 lockfiles are supported by yarn_lock_parser")
-      main_file = File.read(file.gsub('yarn.lock', 'package.json'))
+      main_file = File.read(sibling_file(file, 'package.json'))
 
       work_items = lock_file.reject { |js_package| main_file.include?("#{js_package[:name]}\": \"file:vendor") }
 

--- a/spec/soup/composer_parser_spec.rb
+++ b/spec/soup/composer_parser_spec.rb
@@ -157,6 +157,57 @@ RSpec.describe(SOUP::ComposerParser) do
     end
   end
 
+  context 'when the lockfile lives in a directory whose name contains "lock"' do
+    # Regression test for BUG-04: pre-fix the parser used file.gsub('lock',
+    # 'json'), an unanchored substring substitution that corrupted any path
+    # containing "lock" (e.g. /Users/sherlock/proj/composer.lock).
+    let(:lock_file_path) { '/Users/sherlock/proj/composer.lock' }
+    let(:main_file_path) { '/Users/sherlock/proj/composer.json' }
+    let(:lock_file) do
+      {
+        packages: [
+          { name: 'vendor/x', version: '1.0.0', license: ['MIT'], description: 'X', homepage: '' }
+        ],
+        'packages-dev': []
+      }.to_json
+    end
+
+    before do
+      allow(File).to(receive(:read).with(lock_file_path).and_return(lock_file))
+      allow(File).to(receive(:read).with(main_file_path).and_return('{"require":{"vendor/x":"^1.0"}}'))
+      parser.parse(lock_file_path, packages)
+    end
+
+    it 'reads composer.json from the same directory without corrupting the path' do
+      expect(packages).to(have_key('vendor/x'))
+    end
+  end
+
+  context 'when license is a single String (not an Array)' do
+    # Regression test for BUG-12: Composer's schema permits `license` as a
+    # single string. Pre-fix the parser called `.first` on a String, which
+    # either raised NoMethodError (plain Ruby) or returned the first
+    # character "M" (when ActiveSupport's String#first was loaded).
+    let(:lock_file) do
+      {
+        packages: [
+          {
+            name: 'vendor/str-license',
+            version: '1.0.0',
+            license: 'MIT',
+            description: 'Single-string license',
+            homepage: 'https://example.com'
+          }
+        ],
+        'packages-dev': []
+      }.to_json
+    end
+
+    it 'treats the string as a one-element array and keeps the full SPDX id' do
+      expect(packages['vendor/str-license'].license).to(eq('MIT'))
+    end
+  end
+
   # TEST-04: graceful malformed-lockfile cases. Structurally-empty and
   # unknown-shape JSON should fall through the existing `|| []` guards
   # without raising.

--- a/spec/soup/http_client_spec.rb
+++ b/spec/soup/http_client_spec.rb
@@ -55,4 +55,50 @@ RSpec.describe(SOUP::HttpClient) do
       expect(WebMock).to(have_requested(:get, url).times(2))
     end
   end
+
+  # Regression tests for CFG-01: SOUP_HTTP_TIMEOUT and SOUP_HTTP_MAX_RETRIES
+  # are read from ENV at call time so operators can tune behavior on slow
+  # corporate proxies / rate-limited mirrors without forking.
+  describe '.max_retries' do
+    it 'defaults to 3 when SOUP_HTTP_MAX_RETRIES is unset' do
+      allow(ENV).to(receive(:fetch).and_call_original)
+      allow(ENV).to(receive(:fetch).with('SOUP_HTTP_MAX_RETRIES', 3).and_return(3))
+      expect(described_class.max_retries).to(eq(3))
+    end
+
+    it 'honors SOUP_HTTP_MAX_RETRIES when set' do
+      allow(ENV).to(receive(:fetch).and_call_original)
+      allow(ENV).to(receive(:fetch).with('SOUP_HTTP_MAX_RETRIES', 3).and_return('7'))
+      expect(described_class.max_retries).to(eq(7))
+    end
+  end
+
+  describe '.default_timeout' do
+    it 'defaults to 5 when SOUP_HTTP_TIMEOUT is unset' do
+      allow(ENV).to(receive(:fetch).and_call_original)
+      allow(ENV).to(receive(:fetch).with('SOUP_HTTP_TIMEOUT', 5).and_return(5))
+      expect(described_class.default_timeout).to(eq(5))
+    end
+
+    it 'honors SOUP_HTTP_TIMEOUT when set' do
+      allow(ENV).to(receive(:fetch).and_call_original)
+      allow(ENV).to(receive(:fetch).with('SOUP_HTTP_TIMEOUT', 5).and_return('45'))
+      expect(described_class.default_timeout).to(eq(45))
+    end
+  end
+
+  describe '.get with SOUP_HTTP_MAX_RETRIES env override' do
+    before do
+      allow(ENV).to(receive(:fetch).and_call_original)
+      allow(ENV).to(receive(:fetch).with('SOUP_HTTP_MAX_RETRIES', 3).and_return('1'))
+      allow(ENV).to(receive(:fetch).with('SOUP_HTTP_TIMEOUT', 5).and_return(5))
+      stub_request(:get, url).to_timeout
+    end
+
+    it 'uses the env-resolved max_retries as the default when no kwarg is passed', :aggregate_failures do
+      expect { described_class.get(url) }
+        .to(raise_error(Net::OpenTimeout))
+      expect(WebMock).to(have_requested(:get, url).times(2))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

PR A of 4 covering the remaining Medium items from `docs/code-review.md`. Four small fixes bundled into one PR: parser path safety, Composer license type tolerance, README clarity on default behavior, and runtime HTTP-timeout configurability.

**Key changes:**

- `lib/soup/parsers/base.rb` — new `sibling_file(file, suffix)` helper using `File.dirname/basename`. Preserves the bare-basename shape (a `'composer.lock'` input yields `'composer.json'`, not `'./composer.json'`) so existing `File.read` stubs and bare-basename call sites keep working. (BUG-04)
- `lib/soup/parsers/composer.rb`, `npm.rb`, `yarn.rb` — replace the unanchored `file.gsub('lock'/'package-lock.json'/'yarn.lock', ...)` with `sibling_file(file, ...)`. Pre-fix any path containing the substring (e.g. `/Users/sherlock/proj/composer.lock` → `/Users/jsoner/proj/composer.json`) was corrupted. (BUG-04)
- `lib/soup/parsers/composer.rb#extract_composer_license` — wrap input with `Array(raw)` so a single-String license (which the Composer schema permits) is treated as a one-element array. Pre-fix `.first` either crashed on String (plain Ruby) or returned the first character `"M"` (when ActiveSupport's `String#first` was loaded). (BUG-12)
- `lib/soup/http_client.rb` — replace load-time constants with call-time class methods `.max_retries` and `.default_timeout` that read `SOUP_HTTP_MAX_RETRIES` / `SOUP_HTTP_TIMEOUT` from `ENV` with the previous values as defaults (3 / 5). `Integer()` coercion raises on non-integer inputs. `.get` uses these methods so operators can tune behavior at runtime without forking. (CFG-01)
- `README.md` — Usage section documents that `soup` with no flags is equivalent to `soup --licenses --soup` (DOC-02). Environment Variables table adds rows for `SOUP_HTTP_TIMEOUT` and `SOUP_HTTP_MAX_RETRIES` (CFG-01).
- `spec/soup/composer_parser_spec.rb` — new "when the lockfile lives in a directory whose name contains 'lock'" context (BUG-04 regression) and "when license is a single String (not an Array)" context (BUG-12 regression).
- `spec/soup/http_client_spec.rb` — new `.max_retries` / `.default_timeout` describes covering default and env-override paths, plus a `.get with SOUP_HTTP_MAX_RETRIES env override` describe asserting the call-time read flows into `.get` correctly.

Full RSpec suite: 168 examples, 0 failures, line coverage 98.11%, branch 86.94%. RuboCop clean across `lib/` and `spec/`.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified