### PR TITLE
Medium cluster C: typed SOUP error hierarchy with class-aware assertions

### DIFF
--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -6,6 +6,7 @@ require 'nokogiri'
 require 'tty-prompt'
 
 require_relative '../soup'
+require_relative 'errors'
 require_relative 'http_client'
 require_relative 'options'
 require_relative 'parsers/bundler'
@@ -61,12 +62,12 @@ module SOUP
 
     def validate_config!
       [@options.licenses_file, @options.exceptions_file].each do |file|
-        raise("Configuration file not found: #{file}") unless File.exist?(file)
+        raise(ConfigurationError, "Configuration file not found: #{file}") unless File.exist?(file)
 
         begin
           JSON.parse(File.read(file))
         rescue JSON::ParserError => e
-          raise("Invalid JSON in configuration file #{file}: #{e.message}")
+          raise(ConfigurationError, "Invalid JSON in configuration file #{file}: #{e.message}")
         end
       end
     end
@@ -210,7 +211,7 @@ module SOUP
         return
       end
 
-      raise("No #{label} found for #{package.package}!") if @options.no_prompt
+      raise(MissingMetadataError, "No #{label} found for #{package.package}!") if @options.no_prompt
 
       package.public_send(:"#{field}=", yield(prompt, package))
     end
@@ -218,7 +219,7 @@ module SOUP
     def ensure_metadata_complete!(package)
       return unless package.risk_level.empty? || package.requirements.empty? || package.verification_reasoning.empty?
 
-      raise("Missing information for #{package.package}!")
+      raise(MissingMetadataError, "Missing information for #{package.package}!")
     end
 
     def append_markdown_row(package)

--- a/lib/soup/errors.rb
+++ b/lib/soup/errors.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module SOUP
+  # Base class for all soup-raised errors. Inherits from StandardError so the
+  # top-level rescue in bin/soup.rb (and any caller using `rescue` without
+  # an explicit class) still catches every soup-internal error.
+  class Error < StandardError; end
+
+  # Raised when a soup configuration file (--licenses_file, --exceptions_file)
+  # is missing, unreadable, or contains malformed JSON.
+  class ConfigurationError < Error; end
+
+  # Raised when an input lockfile is structurally malformed, unsupported, or
+  # otherwise cannot be processed by the parser.
+  class InvalidLockfileError < Error; end
+
+  # Raised when a lockfile is recognized but its format version is not
+  # supported (Yarn Berry, npm v1, etc.). A more specific InvalidLockfileError.
+  class UnsupportedFormatError < InvalidLockfileError; end
+
+  # Raised when a package metadata lookup against a remote registry fails in
+  # an unrecoverable way (non-2xx after retries, or registry rejects the
+  # request entirely).
+  class RegistryError < Error; end
+
+  # Raised when registry authentication fails (401 / "Bad credentials" from
+  # GitHub API, etc.). A more specific RegistryError.
+  class AuthenticationError < RegistryError; end
+
+  # Raised when a registry returns a rate-limit response (403/429 with a
+  # rate-limit message from GitHub API, etc.). A more specific RegistryError.
+  class RateLimitError < RegistryError; end
+
+  # Raised when the user is expected to supply missing metadata (risk level,
+  # requirements, verification reasoning) but the run was invoked with
+  # --no_prompt or the metadata is still missing after prompting.
+  class MissingMetadataError < Error; end
+end

--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -2,6 +2,7 @@
 
 require 'parallel'
 
+require_relative '../errors'
 require_relative '../http_client'
 require_relative '../package'
 

--- a/lib/soup/parsers/bundler.rb
+++ b/lib/soup/parsers/bundler.rb
@@ -27,13 +27,13 @@ module SOUP
         latest_url = "https://api.rubygems.org/api/v1/versions/#{spec.name}/latest.json"
         response = HttpClient.get(latest_url)
 
-        raise(http_error_message(response, url: latest_url, package: "#{spec.name} #{spec.version}")) unless response.code == 200
+        raise(RegistryError, http_error_message(response, url: latest_url, package: "#{spec.name} #{spec.version}")) unless response.code == 200
 
         latest_version = JSON.parse(response.body)['version']
         fallback_url = "https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{latest_version}.json"
         response = HttpClient.get(fallback_url)
 
-        raise(http_error_message(response, url: fallback_url, package: "#{spec.name} #{latest_version}")) unless response.code == 200
+        raise(RegistryError, http_error_message(response, url: fallback_url, package: "#{spec.name} #{latest_version}")) unless response.code == 200
       end
 
       package_details = JSON.parse(response.body)

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -53,7 +53,7 @@ module SOUP
         next
       end
 
-      raise("No build.gradle or build.gradle.kts found alongside #{file}")
+      raise(InvalidLockfileError, "No build.gradle or build.gradle.kts found alongside #{file}")
     end
 
     def fetch_package(file, main_file, group_id, artifact_id, version)

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -10,7 +10,10 @@ module SOUP
       direct_deps = (main_file_json['dependencies'] || {}).keys |
                     (main_file_json['devDependencies'] || {}).keys
       all_packages = lock_file['packages'] ||
-                     raise("Unsupported package-lock.json at #{file}: lockfileVersion 2+ (with 'packages' key) is required")
+                     raise(
+                       UnsupportedFormatError,
+                       "Unsupported package-lock.json at #{file}: lockfileVersion 2+ (with 'packages' key) is required"
+                     )
 
       work_items = all_packages.reject { |key, value| key.empty? || value['dev'] }
 

--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -50,7 +50,7 @@ module SOUP
       url = "https://pypi.python.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json"
       response = HttpClient.get(url)
 
-      raise(http_error_message(response, url: url, package: "#{pip_package}==#{version}")) unless response.code == 200
+      raise(RegistryError, http_error_message(response, url: url, package: "#{pip_package}==#{version}")) unless response.code == 200
 
       package_details = JSON.parse(response.body)
       info = package_details['info']

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -11,7 +11,7 @@ module SOUP
       lock_file = lock_file['object'] if lock_file['object']
       main_file = read_main_swift_file(file)
 
-      raise('No main file found!') if main_file.nil?
+      raise(InvalidLockfileError, "No Swift main file found alongside #{file}") if main_file.nil?
 
       token = ENV.fetch('GITHUB_TOKEN', '')
 
@@ -80,8 +80,8 @@ module SOUP
 
       unless response.code == 200
         combined = github_error_message(response)
-        raise('GitHub API: rate limit exceeded. Please set GITHUB_TOKEN to raise the rate limit.') if combined.include?('rate limit')
-        raise('GitHub API: Bad credentials. Please verify GITHUB_TOKEN.') if combined.downcase.include?('bad credentials')
+        raise(RateLimitError, 'GitHub API: rate limit exceeded. Please set GITHUB_TOKEN to raise the rate limit.') if combined.include?('rate limit')
+        raise(AuthenticationError, 'GitHub API: Bad credentials. Please verify GITHUB_TOKEN.') if combined.downcase.include?('bad credentials')
 
         warn(http_error_message(response, url: url, package: pin_id))
         return

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -8,7 +8,10 @@ module SOUP
   class YarnParser < BaseParser
     def parse(file, packages)
       lock_file = YarnLockParser::Parser.parse(file) ||
-                  raise("Unsupported yarn.lock format at #{file}: only Yarn v1 lockfiles are supported by yarn_lock_parser")
+                  raise(
+                    UnsupportedFormatError,
+                    "Unsupported yarn.lock format at #{file}: only Yarn v1 lockfiles are supported by yarn_lock_parser"
+                  )
       main_file = File.read(sibling_file(file, 'package.json'))
 
       work_items = lock_file.reject { |js_package| main_file.include?("#{js_package[:name]}\": \"file:vendor") }
@@ -33,7 +36,7 @@ module SOUP
         return
       end
 
-      raise(http_error_message(response, url: url, package: "#{name}@#{version}")) unless response.code == 200
+      raise(RegistryError, http_error_message(response, url: url, package: "#{name}@#{version}")) unless response.code == 200
 
       versions = JSON.parse(response.body)['versions']
 

--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe(SOUP::Application) do
       it 'raises when config file is missing' do
         app = described_class.new(missing_licenses_args)
         expect { app.execute }
-          .to(raise_error(/Configuration file not found/))
+          .to(raise_error(SOUP::ConfigurationError, /Configuration file not found/))
       end
 
       # Regression test for BUG-08: when --soup is enabled (default) and
@@ -193,7 +193,7 @@ RSpec.describe(SOUP::Application) do
       it 'in --soup mode, preserves the existing cache and markdown when validate_config! raises', :aggregate_failures do
         write_existing_soup_files('{"existing/pkg":{"version":"1.0.0"}}', "# Existing SOUP\n")
         expect { described_class.new(missing_soup_args).execute }
-          .to(raise_error(/Configuration file not found/))
+          .to(raise_error(SOUP::ConfigurationError, /Configuration file not found/))
         expect(File.read(cache_file.path)).to(eq('{"existing/pkg":{"version":"1.0.0"}}'))
         expect(File.read(markdown_file)).to(eq("# Existing SOUP\n"))
       end
@@ -214,7 +214,7 @@ RSpec.describe(SOUP::Application) do
       it 'raises when config file has invalid JSON' do
         args = ['--licenses', '--licenses_file', bad_file.path, '--exceptions_file', exceptions_file.path] + skip_all_parsers
         expect { described_class.new(args).execute }
-          .to(raise_error(/Invalid JSON/))
+          .to(raise_error(SOUP::ConfigurationError, /Invalid JSON/))
       end
     end
 
@@ -240,7 +240,7 @@ RSpec.describe(SOUP::Application) do
       it 'raises with no_prompt when risk_level is missing' do
         app = described_class.new(soup_no_prompt_args(skip: skip_parsers_except_composer))
         expect { app.execute }
-          .to(raise_error(/No risk level found/))
+          .to(raise_error(SOUP::MissingMetadataError, /No risk level found/))
       end
 
       it 'reads cached packages from file when it exists' do
@@ -307,7 +307,7 @@ RSpec.describe(SOUP::Application) do
       it 'saves partial state when check_packages raises an exception', :aggregate_failures do
         app = described_class.new(soup_no_prompt_args(skip: skip_parsers_except_composer))
         expect { app.execute }
-          .to(raise_error(/No risk level found/))
+          .to(raise_error(SOUP::MissingMetadataError, /No risk level found/))
         cache_content = JSON.parse(File.read(cache_file.path))
         expect(cache_content).not_to(be_empty)
       end

--- a/spec/soup/bundler_parser_spec.rb
+++ b/spec/soup/bundler_parser_spec.rb
@@ -72,10 +72,10 @@ RSpec.describe(SOUP::BundlerParser) do
           .to_return(status: 500, body: 'Internal Server Error', headers: { Status: 'Internal Server Error' })
       end
 
-      it 'raises an error' do
+      it 'raises a SOUP::RegistryError with status + url + package context' do
         packages = {}
         expect { parser.parse('Gemfile.lock', packages) }
-          .to(raise_error(RuntimeError))
+          .to(raise_error(SOUP::RegistryError, /HTTP 500.*test-gem.*api\.rubygems\.org/m))
       end
     end
   end

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe(SOUP::GradleParser) do
     it 'raises a clear error rather than a bare ENOENT' do
       packages = {}
       expect { parser.parse('buildscript-gradle.lockfile', packages) }
-        .to(raise_error(/No build\.gradle or build\.gradle\.kts found/))
+        .to(raise_error(SOUP::InvalidLockfileError, /No build\.gradle or build\.gradle\.kts found/))
     end
   end
 

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe(SOUP::NPMParser) do
     it 'raises a clear unsupported-format error', :aggregate_failures do
       packages = {}
       expect { parser.parse('package-lock.json', packages) }
-        .to(raise_error(/Unsupported package-lock\.json/))
+        .to(raise_error(SOUP::UnsupportedFormatError, /Unsupported package-lock\.json/))
       expect(packages).to(be_empty)
     end
   end

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -220,10 +220,10 @@ RSpec.describe(SOUP::SPMParser) do
       allow(File).to(receive(:exist?).with('Package.xcodeproj/project.pbxproj').and_return(false))
     end
 
-    it 'raises an error' do
+    it 'raises a SOUP::InvalidLockfileError naming the file' do
       packages = {}
       expect { parser.parse('Package.resolved', packages) }
-        .to(raise_error('No main file found!'))
+        .to(raise_error(SOUP::InvalidLockfileError, /No Swift main file found/))
     end
   end
 
@@ -261,7 +261,7 @@ RSpec.describe(SOUP::SPMParser) do
     it 'raises on rate limit' do
       packages = {}
       expect { parser.parse('Package.resolved', packages) }
-        .to(raise_error(/rate limit/))
+        .to(raise_error(SOUP::RateLimitError, /rate limit/))
     end
   end
 
@@ -281,7 +281,7 @@ RSpec.describe(SOUP::SPMParser) do
     it 'raises on rate limit even when the reason phrase does not contain the keyword' do
       packages = {}
       expect { parser.parse('Package.resolved', packages) }
-        .to(raise_error(/rate limit/))
+        .to(raise_error(SOUP::RateLimitError, /rate limit/))
     end
   end
 
@@ -363,7 +363,7 @@ RSpec.describe(SOUP::SPMParser) do
     it 'raises on bad credentials' do
       packages = {}
       expect { parser.parse('Package.resolved', packages) }
-        .to(raise_error(/Bad credentials/))
+        .to(raise_error(SOUP::AuthenticationError, /Bad credentials/))
     end
   end
 

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe(SOUP::YarnParser) do
     end
   end
 
-  it 'raises on non-200 response' do
+  it 'raises a SOUP::RegistryError on non-200 response' do
     stub_request(:get, 'https://registry.npmjs.org/lodash')
       .to_return(status: 500, body: 'Server Error')
     packages = {}
     expect { parser.parse('yarn.lock', packages) }
-      .to(raise_error(RuntimeError))
+      .to(raise_error(SOUP::RegistryError, /HTTP 500.*lodash.*registry\.npmjs\.org/m))
   end
 
   it 'handles timeout gracefully', :aggregate_failures do
@@ -123,7 +123,7 @@ RSpec.describe(SOUP::YarnParser) do
     it 'raises a clear unsupported-format error', :aggregate_failures do
       packages = {}
       expect { parser.parse('yarn.lock', packages) }
-        .to(raise_error(/Unsupported yarn\.lock format/))
+        .to(raise_error(SOUP::UnsupportedFormatError, /Unsupported yarn\.lock format/))
       expect(packages).to(be_empty)
     end
   end


### PR DESCRIPTION
## Summary

PR C of 4 covering the testing-quality Medium items from `docs/code-review.md`. Introduces a soup-specific exception hierarchy and tightens every test assertion to match both class AND message.

**Scope note:** TEST-12 (migrate parser specs from `File`-method stubs to `Dir.mktmpdir` fixtures) is intentionally deferred to PR D. PR D's QUAL-01 (extract `fetch_metadata` template into BaseParser) and QUAL-02 (Package refactor) both rewrite the parser specs, so doing TEST-12 first would mean rewriting the same specs twice. PR D will fold the tmpdir migration into the same pass.

**Key changes:**

- `lib/soup/errors.rb` (new) — defines the hierarchy:
  - `SOUP::Error < StandardError` (base; `bin/soup.rb`'s `rescue StandardError` still catches everything)
  - `SOUP::ConfigurationError < SOUP::Error` (missing/malformed config files)
  - `SOUP::InvalidLockfileError < SOUP::Error` (parser cannot interpret the lockfile)
  - `SOUP::UnsupportedFormatError < SOUP::InvalidLockfileError` (Yarn Berry, npm v1)
  - `SOUP::RegistryError < SOUP::Error` (non-2xx registry response)
  - `SOUP::AuthenticationError < SOUP::RegistryError` (GitHub 401 / Bad credentials)
  - `SOUP::RateLimitError < SOUP::RegistryError` (GitHub 403/429 / rate limit)
  - `SOUP::MissingMetadataError < SOUP::Error` (`--no_prompt` without all metadata)
- `lib/soup/application.rb` — `validate_config!` raises `ConfigurationError` (both missing-file and invalid-JSON paths). `prompt_missing_field` and `ensure_metadata_complete!` raise `MissingMetadataError`. Added `require_relative 'errors'`.
- `lib/soup/parsers/base.rb` — added `require_relative '../errors'` so subclasses see the symbols.
- `lib/soup/parsers/bundler.rb` — `RegistryError` on both v2-fallback non-200 raises.
- `lib/soup/parsers/pip.rb` — `RegistryError` on the non-200 raise.
- `lib/soup/parsers/npm.rb` — `UnsupportedFormatError` on the lockfileVersion 1 guard.
- `lib/soup/parsers/yarn.rb` — `UnsupportedFormatError` on the Yarn Berry guard, `RegistryError` on the non-200 raise.
- `lib/soup/parsers/spm.rb` — `InvalidLockfileError` on "no Swift main file found", `RateLimitError` on the rate-limit branch, `AuthenticationError` on the bad-credentials branch.
- `lib/soup/parsers/gradle.rb` — `InvalidLockfileError` on "No build.gradle or build.gradle.kts found".
- `spec/soup/application_spec.rb`, `bundler_parser_spec.rb`, `gradle_parser_spec.rb`, `npm_parser_spec.rb`, `spm_parser_spec.rb`, `yarn_parser_spec.rb` — every `raise_error(/regex/)` upgraded to `raise_error(SOUP::SomeError, /regex/)`. Two previously-asserted `raise_error(RuntimeError)` cases (bundler v2 fallback, yarn 500) were tightened to `raise_error(SOUP::RegistryError, /HTTP 500 ... <package> ... <host>/m)` — exercises both the class AND the `BaseParser#http_error_message` format. The SPM "no main file" case asserts on `SOUP::InvalidLockfileError` plus the new message that names the file.

Full RSpec suite: 165 examples, 0 failures. `linters` reports zero errors across RuboCop, markdownlint, yamllint, hadolint, actionlint, semgrep, and trivy.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified