### PR TITLE
TEST-12 follow-up: real-on-disk fixture context for six parser specs

### DIFF
--- a/spec/soup/bundler_parser_spec.rb
+++ b/spec/soup/bundler_parser_spec.rb
@@ -164,5 +164,43 @@ RSpec.describe(SOUP::BundlerParser) do
           .to(raise_error(Errno::ENOENT))
       end
     end
+
+    # TEST-12 follow-up: parser exercised against real Gemfile + Gemfile.lock
+    # bytes via SoupFixtureHelpers. Overrides the outer LockfileParser /
+    # Bundler.read_file stubs with and_call_original so the real Bundler
+    # parser runs against on-disk content.
+    context 'with real Gemfile.lock + Gemfile fixtures on disk' do
+      # `def` inside a context block defines an instance method on the
+      # example group; it is not a memoized helper and does not count against
+      # RSpec/MultipleMemoizedHelpers like a `let` would.
+      def gemfile_lock_bytes
+        <<~LOCK
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              test-gem (1.0.0)
+          PLATFORMS
+            ruby
+          DEPENDENCIES
+            test-gem
+          BUNDLED WITH
+             2.5.0
+        LOCK
+      end
+
+      before do
+        allow(Bundler::LockfileParser).to(receive(:new).and_call_original)
+        allow(Bundler).to(receive(:read_file).and_call_original)
+        stub_request(:get, 'https://api.rubygems.org/api/v2/rubygems/test-gem/versions/1.0.0.json')
+          .to_return(status: 200, body: v2_response_body)
+      end
+
+      it 'reads Gemfile + Gemfile.lock from disk and lets the real LockfileParser run' do
+        write_fixture('Gemfile', "gem 'test-gem'")
+        lockfile_path = write_fixture('Gemfile.lock', gemfile_lock_bytes)
+        parser.parse(lockfile_path, packages)
+        expect(packages['test-gem']).to(have_attributes(language: 'Ruby', version: '1.0.0', license: 'MIT'))
+      end
+    end
   end
 end

--- a/spec/soup/composer_parser_spec.rb
+++ b/spec/soup/composer_parser_spec.rb
@@ -292,4 +292,32 @@ RSpec.describe(SOUP::ComposerParser) do
       end
     end
   end
+
+  # TEST-12 follow-up: parser exercised against real lockfile bytes via
+  # SoupFixtureHelpers. Uses auto_parse: false so the outer before-hook does
+  # not invoke parser.parse with the stubbed 'composer.lock' literal before
+  # the example writes its real fixture path.
+  context 'with real fixture files on disk', auto_parse: false do
+    let(:tmpdir_lock_content) do
+      {
+        packages: [
+          {
+            name: 'vendor/main-pkg',
+            version: '1.0.0',
+            license: ['MIT'],
+            description: 'Main package',
+            homepage: 'https://example.com'
+          }
+        ],
+        'packages-dev': []
+      }.to_json
+    end
+
+    it 'reads the lockfile + composer.json from disk without File stubs' do
+      write_fixture('composer.json', '{"require":{"vendor/main-pkg":"^1.0"}}')
+      lockfile_path = write_fixture('composer.lock', tmpdir_lock_content)
+      parser.parse(lockfile_path, packages)
+      expect(packages['vendor/main-pkg']).to(have_attributes(language: 'PHP', version: '1.0.0', license: 'MIT'))
+    end
+  end
 end

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -345,5 +345,32 @@ RSpec.describe(SOUP::GradleParser) do
           .to(raise_error(Errno::ENOENT))
       end
     end
+
+    # TEST-12 follow-up: parser exercised against real Gradle fixtures via
+    # SoupFixtureHelpers. File.readlines / File.read stubs bypassed with
+    # and_call_original so real filesystem reads run.
+    context 'with real Gradle fixtures on disk' do
+      let(:tmpdir_lockfile_bytes) do
+        <<~LOCK
+          # This is a Gradle lockfile
+          com.example:library:1.0.0=classpath
+        LOCK
+      end
+
+      before do
+        allow(File).to(receive(:readlines).and_call_original)
+        allow(File).to(receive(:read).and_call_original)
+        stub_request(:get, %r{search\.maven\.org/solrsearch/select})
+          .to_return(status: 200, body: maven_response)
+      end
+
+      it 'reads the lockfile + sibling build.gradle from disk without File stubs' do
+        write_fixture('build.gradle', 'classpath "com.example:library:1.0.0"')
+        lockfile_path = write_fixture('buildscript-gradle.lockfile', tmpdir_lockfile_bytes)
+        packages = {}
+        parser.parse(lockfile_path, packages)
+        expect(packages['com.example:library']).to(have_attributes(language: 'Kotlin', version: '1.0.0', license: 'Apache-2.0'))
+      end
+    end
   end
 end

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -238,4 +238,31 @@ RSpec.describe(SOUP::NPMParser) do
         .to(raise_error(Errno::ENOENT))
     end
   end
+
+  # TEST-12 follow-up: parser exercised against real lockfile bytes via
+  # SoupFixtureHelpers, demonstrating the no-stub pattern for npm.
+  context 'with a real package-lock.json fixture on disk' do
+    let(:lockfile_bytes) do
+      {
+        lockfileVersion: 3,
+        packages: {
+          '': { version: '1.0.0' }, # rubocop:disable Naming/VariableNumber
+          'node_modules/lodash': { version: '4.17.21' }
+        }
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, 'https://registry.npmjs.org/lodash')
+        .to_return(status: 200, body: registry_response)
+    end
+
+    it 'reads both files from disk without File stubs' do
+      write_fixture('package.json', main_file)
+      lockfile_path = write_fixture('package-lock.json', lockfile_bytes)
+      packages = {}
+      parser.parse(lockfile_path, packages)
+      expect(packages['lodash']).to(have_attributes(language: 'JS', version: '4.17.21', license: 'MIT'))
+    end
+  end
 end

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -245,5 +245,32 @@ RSpec.describe(SOUP::PIPParser) do
           .to(raise_error(Errno::ENOENT))
       end
     end
+
+    # TEST-12 follow-up: parser exercised against a real requirements.txt
+    # via SoupFixtureHelpers. Stubs the .in / foreach defaults from the outer
+    # before are bypassed via and_call_original so real File.foreach reads
+    # the tmpdir fixture.
+    context 'with a real requirements.txt fixture on disk' do
+      before do
+        allow(File).to(receive(:exist?).and_call_original)
+        allow(File).to(receive(:foreach).and_call_original)
+        body = {
+          info: {
+            summary: 'HTTP library',
+            home_page: 'https://example.com',
+            classifiers: ['License :: OSI Approved :: Apache Software License'],
+            license: ''
+          }
+        }.to_json
+        stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+          .to_return(status: 200, body: body)
+      end
+
+      it 'reads pinned requirements from disk and skips comments/blanks' do
+        lockfile_path = write_fixture('requirements.txt', "# top-level comment\nrequests==2.31.0\n\n")
+        parser.parse(lockfile_path, packages)
+        expect(packages['requests']).to(have_attributes(language: 'Python', version: '2.31.0'))
+      end
+    end
   end
 end

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -424,5 +424,29 @@ RSpec.describe(SOUP::SPMParser) do
           .to(raise_error(Errno::ENOENT))
       end
     end
+
+    # TEST-12 follow-up: parser exercised against real Package.resolved bytes
+    # via SoupFixtureHelpers, demonstrating the no-stub pattern for spm.
+    context 'with real Package.resolved + Package.swift fixtures on disk' do
+      before do
+        allow(File).to(receive(:exist?).and_call_original)
+        body = {
+          name: 'Alamofire',
+          private: false,
+          license: { spdx_id: 'MIT' },
+          description: 'Elegant HTTP Networking.',
+          html_url: 'https://github.com/Alamofire/Alamofire'
+        }.to_json
+        stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
+          .to_return(status: 200, body: body)
+      end
+
+      it 'reads Package.resolved + sibling Package.swift from disk without File stubs' do
+        write_fixture('Package.swift', '.package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0")')
+        lockfile_path = write_fixture('Package.resolved', resolved_file)
+        parser.parse(lockfile_path, packages)
+        expect(packages['Alamofire']).to(have_attributes(language: 'Swift', version: '5.9.0', license: 'MIT'))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up to PR #335 (Medium cluster D), completing TEST-12. PR #335 landed the `SoupFixtureHelpers` module + an `after`-hook tmpdir cleaner and demonstrated the pattern on `yarn_parser_spec`. This PR extends the pattern to every remaining active parser spec (composer, npm, pip, spm, bundler, gradle).

Existing stub-based examples in these spec files are deliberately left untouched — the audit goal was to prove the helper works for every parser, not to mass-rewrite ~200 examples and risk regression. Future contributors can opt individual examples into the new style incrementally.

**Key changes:**

- `spec/soup/composer_parser_spec.rb` — new `with real fixture files on disk` context that uses the existing `auto_parse: false` opt-out so the outer before-hook does not run `parser.parse('composer.lock', ...)` against the stubbed literal. Writes `composer.json` + `composer.lock` to `Dir.mktmpdir`, asserts the resulting `vendor/main-pkg` Package.
- `spec/soup/npm_parser_spec.rb` — new `with a real package-lock.json fixture on disk` context. Writes `package.json` + a lockfileVersion-3 `package-lock.json`, asserts the lodash Package.
- `spec/soup/pip_parser_spec.rb` — new `with a real requirements.txt fixture on disk` context nested inside the existing `#parse with malformed input` describe; bypasses the outer `File.exist?` / `File.foreach` stubs with `and_call_original` so real filesystem reads run.
- `spec/soup/spm_parser_spec.rb` — new `with real Package.resolved + Package.swift fixtures on disk` context. Reuses the existing `resolved_file` let to stay under `RSpec/MultipleMemoizedHelpers`; bypasses `File.exist?` with `and_call_original`.
- `spec/soup/bundler_parser_spec.rb` — new `with real Gemfile.lock + Gemfile fixtures on disk` context. Bypasses `Bundler::LockfileParser.new` and `Bundler.read_file` stubs with `and_call_original` so the real Bundler parser runs against on-disk bytes. Uses a `def gemfile_lock_bytes` method (rather than a `let`) to avoid bumping `RSpec/MultipleMemoizedHelpers` past 5.
- `spec/soup/gradle_parser_spec.rb` — new `with real Gradle fixtures on disk` context inside the existing `#parse with malformed input` describe; bypasses `File.readlines` / `File.read` stubs with `and_call_original`. Writes `buildscript-gradle.lockfile` + sibling `build.gradle`, asserts the resulting Package.

Full RSpec suite: 197 examples, 0 failures. `linters` reports zero errors across RuboCop, markdownlint, yamllint, hadolint, actionlint, semgrep, and trivy.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): tests-only — extends the SoupFixtureHelpers pattern from PR #335 to every remaining parser spec

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified