### PR TITLE
Parser scale specs and stronger timeout coverage (TEST-303/305/306)

### DIFF
--- a/spec/soup/bundler_parser_spec.rb
+++ b/spec/soup/bundler_parser_spec.rb
@@ -203,4 +203,31 @@ RSpec.describe(SOUP::BundlerParser) do
       end
     end
   end
+
+  # TEST-303: exercise parallel_each at a meaningful fan-out width so a
+  # parser-local concurrency or ordering regression in Bundler is caught
+  # by the spec suite, not just by NPM's existing scale guard.
+  context 'with 100 packages (Parallel.map fan-out)' do
+    let(:specs) do
+      (1..100).map do |i|
+        instance_double(Bundler::LazySpecification, name: "gem-#{i}", version: Gem::Version.new('1.0.0'))
+      end
+    end
+    let(:lock_file) { instance_double(Bundler::LockfileParser, specs: specs) }
+
+    before do
+      (1..100).each do |i|
+        stub_request(:get, "https://api.rubygems.org/api/v2/rubygems/gem-#{i}/versions/1.0.0.json")
+          .to_return(status: 200, body: v2_response_body)
+      end
+    end
+
+    it 'parses all 100 gems without raising and adds them to the hash', :aggregate_failures do
+      packages = {}
+      parser.parse('Gemfile.lock', packages)
+      expect(packages.size).to(eq(100))
+      expect(packages['gem-1']).to(have_attributes(license: 'MIT', version: '1.0.0'))
+      expect(packages['gem-100']).to(have_attributes(license: 'MIT', version: '1.0.0'))
+    end
+  end
 end

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -369,4 +369,46 @@ RSpec.describe(SOUP::GradleParser) do
       end
     end
   end
+
+  # TEST-303: exercise parallel_each at a meaningful fan-out width so a
+  # parser-local concurrency or ordering regression in Gradle is caught
+  # by the spec suite, not just by NPM's existing scale guard.
+  context 'with 100 packages (Parallel.map fan-out)' do
+    let(:lock_content) do
+      (1..100).map { |i| "com.example:lib-#{i}:1.0.0=classpath\n" }
+    end
+
+    let(:main_file) do
+      (1..100).map { |i| %(classpath "com.example:lib-#{i}:1.0.0") }
+              .join("\n")
+    end
+
+    let(:maven_response_for) do
+      lambda do |i|
+        {
+          response: {
+            numFound: 1,
+            docs: [
+              { l: 'Apache-2.0', p: "lib-#{i} description", home_page: 'https://example.com' }
+            ]
+          }
+        }.to_json
+      end
+    end
+
+    before do
+      (1..100).each do |i|
+        stub_request(:get, %r{search\.maven\.org/solrsearch/select.*a:%22lib-#{i}%22})
+          .to_return(status: 200, body: maven_response_for.call(i))
+      end
+    end
+
+    it 'parses all 100 classpath entries without raising and adds them to the hash', :aggregate_failures do
+      packages = {}
+      parser.parse('buildscript-gradle.lockfile', packages)
+      expect(packages.size).to(eq(100))
+      expect(packages['com.example:lib-1']).to(have_attributes(language: 'Kotlin', version: '1.0.0', license: 'Apache-2.0'))
+      expect(packages['com.example:lib-100']).to(have_attributes(language: 'Kotlin', version: '1.0.0', license: 'Apache-2.0'))
+    end
+  end
 end

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -73,12 +73,25 @@ RSpec.describe(SOUP::NPMParser) do
     end
   end
 
-  it 'skips on timeout', :aggregate_failures do
-    stub_request(:get, 'https://registry.npmjs.org/lodash').to_timeout
-    packages = {}
-    expect { parser.parse('package-lock.json', packages) }
-      .not_to(raise_error)
-    expect(packages).to(be_empty)
+  # TEST-305: assert the full retry loop ran and the user saw the
+  # "Aborting after N retries" warning before the parser skipped the
+  # package, not just that parse did not raise.
+  context 'when the registry times out' do
+    let(:url) { 'https://registry.npmjs.org/lodash' }
+    let(:packages) { {} }
+
+    before { stub_request(:get, url).to_timeout }
+
+    it 'emits the "Aborting after N retries" stderr warning' do
+      expect { parser.parse('package-lock.json', packages) }
+        .to(output(/Aborting after \d+ retries/).to_stderr)
+    end
+
+    it 'retries max_retries+1 times before skipping the package', :aggregate_failures do
+      parser.parse('package-lock.json', packages)
+      expect(packages).to(be_empty)
+      expect(a_request(:get, url)).to(have_been_made.times(SOUP::HttpClient.max_retries + 1))
+    end
   end
 
   context 'when license is Unlicense' do

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -273,4 +273,36 @@ RSpec.describe(SOUP::PIPParser) do
       end
     end
   end
+
+  # TEST-303: exercise parallel_each at a meaningful fan-out width so a
+  # parser-local concurrency or ordering regression in PIP is caught
+  # by the spec suite, not just by NPM's existing scale guard.
+  context 'with 100 packages (Parallel.map fan-out)' do
+    let(:requirements_content) do
+      (1..100).map { |i| "pkg-#{i}==1.0.0\n" }
+              .join
+    end
+
+    before do
+      (1..100).each do |i|
+        body = {
+          info: {
+            summary: "pkg-#{i}",
+            home_page: 'https://example.com',
+            classifiers: ['License :: OSI Approved :: MIT License'],
+            license: ''
+          }
+        }.to_json
+        stub_request(:get, "https://pypi.python.org/pypi/pkg-#{i}/json").to_return(status: 200, body: body)
+      end
+    end
+
+    it 'parses all 100 requirements without raising and adds them to the hash', :aggregate_failures do
+      packages = {}
+      parser.parse('requirements.txt', packages)
+      expect(packages.size).to(eq(100))
+      expect(packages['pkg-1']).to(have_attributes(language: 'Python', version: '1.0.0'))
+      expect(packages['pkg-100']).to(have_attributes(language: 'Python', version: '1.0.0'))
+    end
+  end
 end

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -449,4 +449,47 @@ RSpec.describe(SOUP::SPMParser) do
       end
     end
   end
+
+  # TEST-303: exercise parallel_each at a meaningful fan-out width so a
+  # parser-local concurrency or ordering regression in SPM is caught
+  # by the spec suite, not just by NPM's existing scale guard.
+  context 'with 100 packages (Parallel.map fan-out)' do
+    let(:resolved_file) do
+      pins =
+        (1..100).map do |i|
+          {
+            identity: "pkg-#{i}",
+            location: "https://github.com/example-org/pkg-#{i}.git",
+            state: { version: '1.0.0' }
+          }
+        end
+      { pins: pins }.to_json
+    end
+
+    let(:main_file_content) do
+      (1..100).map { |i| %(.package(url: "https://github.com/example-org/pkg-#{i}.git", from: "1.0.0")) }
+              .join("\n")
+    end
+
+    before do
+      (1..100).each do |i|
+        body = {
+          name: "pkg-#{i}",
+          private: false,
+          license: { spdx_id: 'MIT' },
+          description: "pkg-#{i} description",
+          html_url: "https://github.com/example-org/pkg-#{i}"
+        }.to_json
+        stub_request(:get, "https://api.github.com/repos/example-org/pkg-#{i}").to_return(status: 200, body: body)
+      end
+    end
+
+    it 'parses all 100 pins without raising and adds them to the hash', :aggregate_failures do
+      packages = {}
+      parser.parse('Package.resolved', packages)
+      expect(packages.size).to(eq(100))
+      expect(packages['pkg-1']).to(have_attributes(language: 'Swift', version: '1.0.0', license: 'MIT'))
+      expect(packages['pkg-100']).to(have_attributes(language: 'Swift', version: '1.0.0', license: 'MIT'))
+    end
+  end
 end

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -67,12 +67,25 @@ RSpec.describe(SOUP::YarnParser) do
       .to(raise_error(SOUP::RegistryError, /HTTP 500.*lodash.*registry\.npmjs\.org/m))
   end
 
-  it 'handles timeout gracefully', :aggregate_failures do
-    stub_request(:get, 'https://registry.npmjs.org/lodash').to_timeout
-    packages = {}
-    expect { parser.parse('yarn.lock', packages) }
-      .not_to(raise_error)
-    expect(packages).to(be_empty)
+  # TEST-305: assert the full retry loop ran and the user saw the
+  # "Aborting after N retries" warning before the parser skipped the
+  # package, not just that parse did not raise.
+  context 'when the registry times out' do
+    let(:url) { 'https://registry.npmjs.org/lodash' }
+    let(:packages) { {} }
+
+    before { stub_request(:get, url).to_timeout }
+
+    it 'emits the "Aborting after N retries" stderr warning' do
+      expect { parser.parse('yarn.lock', packages) }
+        .to(output(/Aborting after \d+ retries/).to_stderr)
+    end
+
+    it 'retries max_retries+1 times before skipping the package', :aggregate_failures do
+      parser.parse('yarn.lock', packages)
+      expect(packages).to(be_empty)
+      expect(a_request(:get, url)).to(have_been_made.times(SOUP::HttpClient.max_retries + 1))
+    end
   end
 
   context 'when the resolved version is not in the registry' do
@@ -199,6 +212,55 @@ RSpec.describe(SOUP::YarnParser) do
       packages = {}
       parser.parse(lockfile_path, packages)
       expect(packages['lodash']).to(have_attributes(language: 'JS', version: '4.17.21', license: 'MIT'))
+    end
+  end
+
+  # TEST-306: parity with bundler / composer which both cover an explicit
+  # empty-lockfile context. yarn_lock_parser 0.1.0 returns nil for empty
+  # input, so the parser surfaces the same UnsupportedFormatError as the
+  # Yarn Berry case (BUG-01) but via a real on-disk file rather than a stub.
+  context 'with an empty yarn.lock fixture on disk' do
+    let(:packages) { {} }
+    let(:lockfile_path) do
+      write_fixture('package.json', '{}')
+      write_fixture('yarn.lock', '')
+    end
+
+    before { allow(YarnLockParser::Parser).to(receive(:parse).and_call_original) }
+
+    it 'raises UnsupportedFormatError when YarnLockParser cannot parse the file', :aggregate_failures do
+      expect { parser.parse(lockfile_path, packages) }
+        .to(raise_error(SOUP::UnsupportedFormatError, /Unsupported yarn\.lock format/))
+      expect(packages).to(be_empty)
+    end
+  end
+
+  # TEST-303: exercise parallel_each at a meaningful fan-out width so a
+  # parser-local concurrency or ordering regression in Yarn is caught
+  # by the spec suite, not just by NPM's existing scale guard.
+  context 'with 100 packages (Parallel.map fan-out)' do
+    let(:parsed_lock) do
+      (1..100).map { |i| { name: "pkg-#{i}", version: '1.0.0' } }
+    end
+
+    let(:main_file) do
+      deps = (1..100).to_h { |i| ["pkg-#{i}", '^1.0.0'] }
+      { dependencies: deps }.to_json
+    end
+
+    before do
+      (1..100).each do |i|
+        body = { versions: { '1.0.0': { license: 'MIT', description: "pkg-#{i}", homepage: '' } } }.to_json
+        stub_request(:get, "https://registry.npmjs.org/pkg-#{i}").to_return(status: 200, body: body)
+      end
+    end
+
+    it 'parses all 100 packages without raising and adds them to the hash', :aggregate_failures do
+      packages = {}
+      parser.parse('yarn.lock', packages)
+      expect(packages.size).to(eq(100))
+      expect(packages['pkg-1']).to(have_attributes(language: 'JS', version: '1.0.0', license: 'MIT'))
+      expect(packages['pkg-100']).to(have_attributes(language: 'JS', version: '1.0.0', license: 'MIT'))
     end
   end
 end


### PR DESCRIPTION
## Summary

Addresses three test-coverage findings from `docs/code-review.md`:

- **TEST-303:** before this PR, only `npm_parser_spec.rb` exercised `parallel_each` at a meaningful fan-out width (100 packages). The five other parallel parsers — `yarn`, `bundler`, `pip`, `spm`, `gradle` — were tested at N≤3 work items, so a parser-local concurrency or ordering regression could have shipped green because only NPM's scale guard would fail.
- **TEST-305:** the existing "skips on timeout" specs for `npm` and `yarn` asserted only that `parse` did not raise and that `packages` ended up empty. They did not verify the retry loop in `HttpClient.get` actually executed `max_retries + 1` HTTP calls, nor that the "Aborting after N retries" warning reached stderr. A regression that swallowed the timeout silently (or bypassed the retry loop entirely) would have passed.
- **TEST-306:** `bundler`, `composer`, and others have an explicit "empty / malformed lockfile" context using on-disk fixtures. Yarn had only the BUG-01 nil-from-YarnLockParser stub-based regression test and an ENOENT path — no real-byte empty-file context.

**Key changes:**

- Add a 100-package `Parallel.map` fan-out context to each of `yarn`, `bundler`, `pip`, `spm`, `gradle` parser specs, mirroring the existing NPM scale spec at lines 198-226 of `npm_parser_spec.rb`.
- Replace the NPM and Yarn `skips on timeout` examples with a `context` block that adds two stronger assertions: stderr matches `/Aborting after \d+ retries/` and `WebMock` recorded exactly `SOUP::HttpClient.max_retries + 1` requests.
- Add an "empty yarn.lock fixture on disk" context to `yarn_parser_spec.rb` that uses `SoupFixtureHelpers#write_fixture` to write a real 0-byte `yarn.lock` and asserts the parser surfaces `SOUP::UnsupportedFormatError`.
- No production code changed.

Suite goes from 218 to 226 examples; coverage stays at 98.33% line / 88.29% branch.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): Test coverage improvements for previously under-tested parser scale and timeout paths (TEST-303/305/306 from `docs/code-review.md`).

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified