### PR TITLE
Remove stale CocoaPods archaeology comment and clarify README (QUAL-010/COMPAT-003)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following package managers are supported:
 * SPM (Package.resolved)
 * Yarn (yarn.lock)
 
-Note: CocoaPods support is implemented but currently disabled due to a dependency conflict. The `cocoapods-core` gem requires `activesupport < 8`, which is incompatible with the current ActiveSupport version used by this project.
+Note: CocoaPods (`Podfile.lock`) support was removed pending upstream compatibility. The `cocoapods-core` gem requires `activesupport < 8`, which is incompatible with the ActiveSupport version this project depends on. `Podfile.lock` files are currently skipped silently; support will be reinstated once `cocoapods-core` upgrades.
 
 The soup file is generated in `./docs/soup.md` and a cache file `.soup.json` is used to preserved previously entered
 choices.

--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -29,10 +29,7 @@ module SOUP
     'gradle.lockfile': { parser: GradleParser, skip: :skip_gradle },
     'Package.resolved': { parser: SPMParser, skip: :skip_spm },
     'package-lock.json': { parser: NPMParser, skip: :skip_npm },
-    # Podfile.lock was previously handled by SOUP::CocoaPodsParser. Removed
-    # because cocoapods-core requires activesupport < 8 which is incompatible
-    # with this project's runtime. Track follow-up to restore CocoaPods support
-    # once cocoapods-core picks up activesupport 8.
+    # Podfile.lock support removed: cocoapods-core requires activesupport < 8.
     'requirements.txt': { parser: PIPParser, skip: :skip_pip },
     'yarn.lock': { parser: YarnParser, skip: :skip_yarn }
   }.freeze


### PR DESCRIPTION
## Summary

Addresses two CocoaPods-related findings from `docs/code-review.md`. Both are about documentation drift after `lib/soup/parsers/cocoapods.rb` (43 LOC) was deleted in commit `2747b00` without updating the surrounding narrative:

- **QUAL-010:** the comment block embedded inside the frozen `PARSER_REGISTRY` literal at `lib/soup/application.rb:32-35` promised a "follow-up to restore CocoaPods support once cocoapods-core picks up activesupport 8" with no owner, issue link, or due date. A TODO with no tracking mechanism is documentation theater — readers grep for `SOUP::CocoaPodsParser` and find nothing, then have to reconstruct the story from git history.
- **COMPAT-003:** `README.md:41` claimed *"CocoaPods support is implemented but currently disabled due to a dependency conflict."* The parser file is gone, no `--skip_cocoapods`-style re-enable flag exists, and iOS users with a `Podfile.lock` in their tree get zero output and zero warning. The phrasing misled iOS consumers about what to expect.

**Key changes:**

- Replace the four-line stale TODO at `lib/soup/application.rb:32-35` with a single-line note: `# Podfile.lock support removed: cocoapods-core requires activesupport < 8.`
- Reword `README.md:41` from "implemented but currently disabled" to "support was removed pending upstream compatibility" and explicitly state that `Podfile.lock` files are silently skipped today.
- No production code changed; no test changes needed (existing 218-example suite still passes, since `SOUP::CocoaPodsParser` was already absent from `PARSER_REGISTRY`).

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Pure documentation / in-code comment edits; the existing 218-example suite still passes unchanged.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified