### PR TITLE
Add Ruby license to allow-list and enable license check in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
       with:
         ssh-key: "${{secrets.SSH_KEY}}"
         github-token: "${{secrets.GH_PAT}}"
-        parameters: "--no_prompt --soup"
+        parameters: "--no_prompt"
   ruby_unit_tests:
     name: Ruby Unit Tests
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         ssh-key: "${{secrets.SSH_KEY}}"
         github-token: "${{secrets.GH_PAT}}"
-        parameters: "--no_prompt --soup"
+        parameters: "--no_prompt"
         skip-checkout: 'true'
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7

--- a/config/licenses.json
+++ b/config/licenses.json
@@ -10,6 +10,7 @@
   "MIT",
   "PSF",
   "Python",
+  "Ruby",
   "Unlicense",
   "WTFPL",
   "zlib"


### PR DESCRIPTION
## Summary

soup's bundled license allow-list (`config/licenses.json`) was missing the
`Ruby` license. Because license matching is a case-insensitive substring test and
rubygems reports these gems' license as the bare string `Ruby` (not
`Ruby OR BSD-2-Clause`), every Ruby-licensed gem was wrongly flagged as
non-compliant. Running `soup` in its default mode (or with `--licenses`) against
any Ruby project using stdlib-extracted gems (`json`, `uri`, `csv`, `optparse`,
...) failed with `Invalid license Ruby found` and a non-zero exit code. This
slipped past this repo's CI because the `Licenses` job invoked soup with `--soup`,
which suppresses the license check.

The `Ruby` license is a permissive, non-copyleft, commercial-safe license
(dual-licensed with BSD-2-Clause, which is already on the allow-list), so it
belongs alongside MIT/Apache/BSD/ISC.

**Key changes:**

- Add `Ruby` to `config/licenses.json` so Ruby-licensed dependencies pass the compliance gate.
- Drop `--soup` from the `Licenses` job in both `.github/workflows/build.yml` and `.github/workflows/dependencies.yml`; soup now runs with `--no_prompt`, which enables both the license check and SOUP generation. CI (PR builds and the weekly dependency-update cron) therefore now enforces license compliance against soup's own dependencies (verified locally: exit code went 1 -> 0, and a `--no_prompt` run with `Ruby` allowed completes cleanly with no missing-metadata bail since `.soup.json` is already 63/63 complete).

> Note: the `Licenses Check` on this PR will be red until soup 1.8.2 is released. The `ci-actions/soup@v2` action runs the latest *released* soup tag (currently 1.8.1, which predates this fix), so the check can only pass once a release ships the `Ruby` entry. Intended to be admin-merged, then released.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: CI now runs the license check against soup's own Ruby-licensed dependencies, so dropping `Ruby` from the allow-list fails the build automatically.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
