### PR TITLE
Sync architecture docs with code and disable MultilineMethodSignature cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,11 @@ Style/TopLevelMethodDefinition:
   Enabled: false
 Style/YodaExpression:
   Enabled: false
+# Autocorrect for this cop collapses multi-line method signatures and can drop
+# inline `# rubocop:disable` directives in the process. See:
+# https://docs.rubocop.org/rubocop/latest/cops_style.html#stylemultilinemethodsignature
+Style/MultilineMethodSignature:
+  Enabled: false
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
 Minitest/NoTestCases:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,6 +149,7 @@
 
 - `self.sanitize_description(text, first_sentence:, strip_markdown:)`: Class method that sanitizes package descriptions by returning nil for nil/empty input, extracting the first sentence, wrapping URLs, and stripping markdown characters
 - Attributes: `file`, `language`, `package`, `version`, `license`, `description`, `website`, `last_verified_at`, `risk_level`, `requirements`, `verification_reasoning`, `dependency`
+- `verified?`: Returns true when all four verification fields (`last_verified_at`, `risk_level`, `requirements`, `verification_reasoning`) are non-empty
 - `as_json`: Serializes package to JSON format
 - `to_json`: JSON string representation
 
@@ -162,7 +163,6 @@
 
 - `SUCCESS_EXIT_CODE`: 0
 - `ERROR_EXIT_CODE`: 1
-- `FAILURE_EXIT_CODE`: 2
 
 ### SOUP::Error Hierarchy
 
@@ -189,10 +189,12 @@
 
 **Key Components:**
 
-- `MAX_RETRIES`: Maximum retry attempts (3)
-- `DEFAULT_TIMEOUT`: HTTP request timeout in seconds (5)
+- `DEFAULT_MAX_RETRIES`: Default maximum retry attempts (3); private constant
+- `DEFAULT_TIMEOUT_SECONDS`: Default HTTP request timeout in seconds (5); private constant
 - `THREAD_COUNT`: Public constant set to `Etc.nprocessors`; used by all parsers as the thread-pool size for parallel metadata fetching
-- `self.get(url, max_retries:, **options)`: Performs HTTP GET with automatic retry on `Net::OpenTimeout` and `Net::ReadTimeout`
+- `self.max_retries`: Returns the retry count, overridable at runtime via the `SOUP_HTTP_MAX_RETRIES` environment variable
+- `self.default_timeout`: Returns the request timeout in seconds, overridable at runtime via the `SOUP_HTTP_TIMEOUT` environment variable
+- `self.get(url, max_retries: nil, **options)`: Performs HTTP GET with automatic retry on `Net::OpenTimeout` and `Net::ReadTimeout`
 
 **External Dependencies:**
 
@@ -219,9 +221,12 @@
 
 - `parse(file, packages)`: Abstract method that raises `NotImplementedError` unless overridden by a subclass
 - `parallel_each(work_items, packages, &)`: Fetches metadata for the work items concurrently via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)` and collects the results
+- `collect_packages(results, packages)`: Compacts the fetched results and keys them by package name into the packages hash
 - `build_package(...)`: Constructs a `SOUP::Package` with normalized fields
 - `normalize_license(license)`: Maps Unlicense and URL-style license values to `NOASSERTION`
 - `sibling_file(file, suffix)`: Resolves a sibling manifest path next to a lock file
+- `lookup_npm_registry_version(payload, name:, version:)`: Extracts a specific version hash from an npm-style registry payload; shared by the NPM and Yarn parsers
+- `http_error_message(response, url:, package:)`: Builds an actionable error message (status code, URL, package, truncated body) for non-2xx responses
 - `NOASSERTION_LICENSE`: Public constant for the `NOASSERTION` license value
 
 **External Dependencies:**
@@ -420,11 +425,11 @@ Validation criteria for SOUP entries: Accuracy (Requirements match actual usage)
 
 **Implementation:**
 
-1. Attempts HTTP GET request with `DEFAULT_TIMEOUT` (5 seconds)
+1. Attempts HTTP GET request with the configured timeout (`DEFAULT_TIMEOUT_SECONDS`, 5 seconds by default; overridable via `SOUP_HTTP_TIMEOUT`)
 2. On `Net::OpenTimeout` or `Net::ReadTimeout`:
    - Increments retry counter
    - Logs retry attempt with counter
-   - Retries up to `MAX_RETRIES` (3) times
+   - Retries up to the configured maximum (`DEFAULT_MAX_RETRIES`, 3 by default; overridable via `SOUP_HTTP_MAX_RETRIES`)
    - Raises the exception after max retries are exhausted
 
 ### Parallel Metadata Fetching Algorithm
@@ -464,7 +469,7 @@ Recoverable failures raise a subclass of `SOUP::Error` (`lib/soup/errors.rb`); t
 | Missing package metadata | Logs warning and continues processing other packages | NPM, Gradle parsers |
 | Missing required IEC 62304 fields | Raises `MissingMetadataError` in `--no_prompt` mode, prompts user otherwise | `lib/soup/application.rb` in `prompt_missing_field` / `ensure_metadata_complete!` methods |
 | Partial execution failure | Persists partial state via `ensure` block so progress is not lost | `lib/soup/application.rb` in `execute` method |
-| Unhandled exceptions | Displays error message; backtrace only shown when `ENV['DEBUG']` is set | `bin/soup.rb` top-level rescue |
+| Unhandled exceptions | Displays error message and the top frames of the backtrace; full backtrace shown only when `ENV['DEBUG']` is set | `bin/soup.rb` top-level rescue |
 
 ### Security Controls
 
@@ -480,7 +485,7 @@ Recoverable failures raise a subclass of `SOUP::Error` (`lib/soup/errors.rb`); t
 
 | Control | Description |
 | :--- | :--- |
-| Exit codes | Defined exit codes for success (0), error (1), and failure (2) |
+| Exit codes | Defined exit codes for success (0) and error (1) |
 | Cache persistence | User-entered metadata cached in `.soup.json` to avoid re-entry |
 | CI/CD mode | `--no_prompt` flag for non-interactive execution |
 | Selective parsing | Skip flags allow excluding specific package managers |


### PR DESCRIPTION
## Summary

Brings `docs/architecture.md` back in sync with the current code and disables a RuboCop cop whose autocorrect was unsafe for this codebase. No runtime behavior changes.

**Key changes:**

- `.rubocop.yml`: Disable `Style/MultilineMethodSignature`. Its autocorrect collapses multi-line method signatures and can drop inline `# rubocop:disable` directives; a comment with a link to the cop docs explains why.
- `docs/architecture.md`: Document the `Package#verified?` predicate (true when all four IEC 62304 verification fields are present).
- `docs/architecture.md`: Update the `HttpClient` section — rename constants to private `DEFAULT_MAX_RETRIES` / `DEFAULT_TIMEOUT_SECONDS`, document the `self.max_retries` / `self.default_timeout` accessors and their `SOUP_HTTP_MAX_RETRIES` / `SOUP_HTTP_TIMEOUT` env-var overrides, and update the retry/timeout algorithm description accordingly.
- `docs/architecture.md`: Document the new parser helpers `collect_packages`, `lookup_npm_registry_version`, and `http_error_message`.
- `docs/architecture.md`: Drop the removed `FAILURE_EXIT_CODE` (2) so exit codes reflect success (0) and error (1) only, in both the constants list and the security-controls table.
- `docs/architecture.md`: Note that unhandled exceptions now show the top backtrace frames, with the full backtrace gated behind `ENV['DEBUG']`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation and lint-config-only change with no runtime code.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
