### PR TITLE
Fix SPM parser for Xcode-managed Package.resolved nested in .xcodeproj

### DIFF
--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -25,7 +25,8 @@ module SOUP
     # Locate the Swift manifest associated with a Package.resolved file.
     # Tries, in order: the sibling Package.swift (or matching <Name>.swift),
     # the enclosing Tuist/Dependencies.swift if the resolved file lives under a
-    # Tuist directory, and finally the sibling <Name>.xcodeproj/project.pbxproj.
+    # Tuist directory, the sibling <Name>.xcodeproj/project.pbxproj, and finally
+    # the project.pbxproj of an enclosing *.xcodeproj higher up the tree.
     # Path joining uses File.dirname + File.basename so directories containing
     # dots in their name do not corrupt the candidate paths.
     def read_main_swift_file(file)
@@ -40,6 +41,30 @@ module SOUP
 
       xcodeproj = path_join(dir, "#{base}.xcodeproj/project.pbxproj")
       return File.read(xcodeproj) if File.exist?(xcodeproj)
+
+      enclosing_pbxproj = enclosing_xcodeproj_pbxproj(dir)
+      return File.read(enclosing_pbxproj) if enclosing_pbxproj
+
+      nil
+    end
+
+    # Standard Xcode-managed SPM places Package.resolved deep inside the project
+    # bundle, e.g. <Name>.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+    # (or under a sibling .xcworkspace). None of the adjacent-file checks match
+    # that layout, so walk up the ancestors and return the project.pbxproj of the
+    # first enclosing *.xcodeproj. That pbxproj names the direct package
+    # dependencies, which is all read_main_swift_file is consulted for.
+    def enclosing_xcodeproj_pbxproj(dir)
+      current = File.expand_path(dir)
+
+      while current != File.dirname(current)
+        if File.extname(current) == '.xcodeproj'
+          pbxproj = File.join(current, 'project.pbxproj')
+          return pbxproj if File.exist?(pbxproj)
+        end
+
+        current = File.dirname(current)
+      end
 
       nil
     end

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -193,6 +193,32 @@ RSpec.describe(SOUP::SPMParser) do
     end
   end
 
+  context 'when Package.resolved is nested inside an Xcode-managed .xcodeproj bundle' do
+    # Regression test: a standard Xcode project (not an SPM package, not Tuist)
+    # stores Package.resolved at
+    # <Name>.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved.
+    # None of the adjacent-file checks match, so the parser must walk up to the
+    # enclosing .xcodeproj/project.pbxproj. Pre-fix this raised
+    # InvalidLockfileError and aborted the whole soup run.
+    let(:lockfile_path) do
+      write_fixture('MyApp.xcodeproj/project.pbxproj', main_file_content)
+      write_fixture('MyApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', resolved_file)
+    end
+
+    before do
+      stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
+        .to_return(status: 200, body: github_response)
+    end
+
+    it 'reads the enclosing project.pbxproj as the main file', :aggregate_failures do
+      packages = {}
+      parser.parse(lockfile_path, packages)
+      expect(packages).to(have_key('Alamofire'))
+      # Named in the pbxproj => treated as a direct dependency, not transitive.
+      expect(packages['Alamofire'].dependency).to(be(false))
+    end
+  end
+
   context 'when the project directory contains a dot in its name' do
     # Regression test for BUG-011: a previous implementation used
     # file.split('.').first to derive the xcodeproj path, which truncated


### PR DESCRIPTION
## Summary

Running soup against a standard Xcode project that uses Swift Package Manager (e.g. `pnp-ios`) aborted the entire run with `Error: No Swift main file found alongside .../swiftpm/Package.resolved`.

Xcode stores the resolved file at the project-managed path `<Name>.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`. The SPM parser's `read_main_swift_file` only looked for the Swift manifest *adjacent* to the resolved file (sibling `Package.swift`, a Tuist `Dependencies.swift`, or sibling `<base>.xcodeproj/project.pbxproj`). None of those match this layout, so it returned `nil` and raised `InvalidLockfileError` — which is not rescued per file, so the whole run died before any package was processed.

This adds a fallback that walks up the directory tree to the first enclosing `*.xcodeproj` and reads its `project.pbxproj` (the canonical location for Xcode-managed SPM dependencies). That pbxproj names the direct package dependencies, which is all the main file is consulted for (direct-vs-transitive detection).

Verified end-to-end against `pnp-ios` (now exits 0, processes all 67 SPM packages plus npm). Re-ran soup against `pnp-android` (gradle/bundler/npm) and `pnp-protobuf` (composer/npm) to confirm no regression — both still exit 0; the new code path only engages when the adjacent-file checks fail.

**Key changes:**

- `lib/soup/parsers/spm.rb`: add `enclosing_xcodeproj_pbxproj` helper and use it as a final fallback in `read_main_swift_file` to locate the `project.pbxproj` of an enclosing `*.xcodeproj` higher up the tree.
- `spec/soup/spm_parser_spec.rb`: add a regression test exercising a `Package.resolved` nested in an Xcode-managed `.xcodeproj` bundle, asserting the package is found and flagged as a direct dependency.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified