### PR TITLE
Fix BUG-003: exact/boundary dependency classification across parsers

### DIFF
--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -63,6 +63,22 @@ module SOUP
       File.join(dir, suffix)
     end
 
+    # Token-boundary test for "is this dependency declared directly in the
+    # manifest". A bare String#include? misclassifies a package whose name is a
+    # substring of another manifest token (e.g. coordinate androidx.core:core
+    # matching androidx.core:core-ktx, or repo Alamofire matching AlamofireImage).
+    # `token` matches only when it is not flanked by identifier characters
+    # (letters, digits, '_', '-'); '.', ':', '/', and quotes therefore act as
+    # boundaries, so Gradle "group:artifact" still matches "group:artifact:1.2.3"
+    # and a Swift repo name still matches ".../Alamofire.git".
+    #
+    # Used only by parsers whose manifest is source code (Gradle build scripts,
+    # Swift Package.swift/pbxproj) and so cannot be parsed into an exact
+    # dependency set the way the npm/yarn/composer/bundler manifests can.
+    def manifest_mentions?(main_file, token)
+      main_file.match?(/(?<![\w-])#{Regexp.escape(token)}(?![\w-])/)
+    end
+
     # Look up a specific package version inside an npm-style registry payload
     # (whose shape is `{ "versions": { "<version>": { ... } } }`). Returns the
     # per-version hash, or nil + a stderr warn if the registry response is

--- a/lib/soup/parsers/bundler.rb
+++ b/lib/soup/parsers/bundler.rb
@@ -9,16 +9,19 @@ module SOUP
   class BundlerParser < BaseParser
     def parse(file, packages)
       lock_file = Bundler::LockfileParser.new(Bundler.read_file(file))
-      main_file = File.read(file.sub(/\.lock$/, ''))
+      # The lockfile's DEPENDENCIES section lists exactly the gems declared in
+      # the Gemfile (direct deps); everything else in specs is transitive. This
+      # is an exact name match, unlike a String#include? scan of the Gemfile.
+      direct_deps = lock_file.dependencies.keys
 
       parallel_each(lock_file.specs, packages) do |spec|
-        fetch_package(file, main_file, spec)
+        fetch_package(file, direct_deps, spec)
       end
     end
 
     private
 
-    def fetch_package(file, main_file, spec)
+    def fetch_package(file, direct_deps, spec)
       puts("Checking #{spec.name} #{spec.version}...")
       version_url = "https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{spec.version}.json"
       response = HttpClient.get(version_url)
@@ -46,7 +49,7 @@ module SOUP
         license: package_details['licenses']&.first&.strip,
         description: Package.sanitize_description(package_details['info'], first_sentence: true),
         website: package_details['homepage_uri']&.strip,
-        dependency: !main_file.include?(spec.name)
+        dependency: !direct_deps.include?(spec.name)
       )
     end
   end

--- a/lib/soup/parsers/composer.rb
+++ b/lib/soup/parsers/composer.rb
@@ -8,7 +8,11 @@ module SOUP
   class ComposerParser < BaseParser
     def parse(file, packages)
       lock_file = JSON.parse(File.read(file))
-      main_file = File.read(sibling_file(file, 'composer.json'))
+      main_file_json = JSON.parse(File.read(sibling_file(file, 'composer.json')))
+      # require / require-dev keys are exact "vendor/name" strings (direct deps);
+      # match those instead of substring-scanning the raw composer.json text.
+      direct_deps = (main_file_json['require'] || {}).keys |
+                    (main_file_json['require-dev'] || {}).keys
       all_packages = (lock_file['packages'] || []) + (lock_file['packages-dev'] || [])
 
       all_packages.each do |php_package|
@@ -22,7 +26,7 @@ module SOUP
           license: extract_composer_license(php_package['license']),
           description: Package.sanitize_description(php_package['description'], first_sentence: true),
           website: php_package['homepage']&.strip,
-          dependency: !main_file.include?(php_package['name'])
+          dependency: !direct_deps.include?(php_package['name'])
         )
         packages[package.package] = package
       end

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -105,7 +105,7 @@ module SOUP
         license: license,
         description: Package.sanitize_description(description),
         website: website,
-        dependency: !main_file.include?("#{group_id}:#{artifact_id}")
+        dependency: !manifest_mentions?(main_file, "#{group_id}:#{artifact_id}")
       )
     end
   end

--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -9,13 +9,13 @@ module SOUP
     LOOSE_CONSTRAINT_PATTERN = /[<>!~]/
     private_constant :LOOSE_CONSTRAINT_PATTERN
 
+    # Leading distribution name of a requirement line, before any extras,
+    # version constraint, or environment marker (PEP 508).
+    REQUIREMENT_NAME_PATTERN = /\A[A-Za-z0-9._-]+/
+    private_constant :REQUIREMENT_NAME_PATTERN
+
     def parse(file, packages)
-      main_file =
-        if File.exist?(file.gsub('.txt', '.in'))
-          File.read(file.gsub('.txt', '.in'))
-        else
-          ''
-        end
+      direct_deps = read_direct_dependencies(file)
 
       work_items = []
       File.foreach(file) do |line|
@@ -39,13 +39,37 @@ module SOUP
       end
 
       parallel_each(work_items, packages) do |pip_package, version|
-        fetch_package(file, main_file, pip_package, version)
+        fetch_package(file, direct_deps, pip_package, version)
       end
     end
 
     private
 
-    def fetch_package(file, main_file, pip_package, version)
+    # Direct dependencies are the names declared in the sibling requirements.in
+    # (the compiled-from source). Returns PEP 503-normalized names for exact
+    # comparison; an empty list (no .in file) leaves every package transitive,
+    # matching the previous empty-main_file behavior.
+    def read_direct_dependencies(file)
+      in_file = file.gsub('.txt', '.in')
+      return [] unless File.exist?(in_file)
+
+      File.read(in_file).each_line.filter_map do |line|
+        line = line.split('#', 2).first.to_s.strip
+        next if line.empty?
+        next if line.start_with?('-') # pip directives such as -r, -c, --hash
+
+        match = line.match(REQUIREMENT_NAME_PATTERN)
+        normalize_pip_name(match.to_s) if match
+      end
+    end
+
+    # PEP 503 name normalization: lowercase, with runs of -, _ and . collapsed
+    # to a single -, so e.g. "Foo.Bar" and "foo_bar" compare equal.
+    def normalize_pip_name(name)
+      name.downcase.gsub(/[-_.]+/, '-')
+    end
+
+    def fetch_package(file, direct_deps, pip_package, version)
       puts("Checking #{pip_package} #{version}...")
       url = "https://pypi.python.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json"
       response = HttpClient.get(url)
@@ -63,7 +87,7 @@ module SOUP
         license: extract_pip_license(info),
         description: Package.sanitize_description(info['summary'], first_sentence: true),
         website: info['home_page']&.strip,
-        dependency: !main_file.include?(pip_package)
+        dependency: !direct_deps.include?(normalize_pip_name(pip_package.sub(/\[[^\]]+\]/, '')))
       )
     end
 

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -123,7 +123,7 @@ module SOUP
         license: package_details.dig('license', 'spdx_id')&.strip,
         description: Package.sanitize_description(package_details['description'], first_sentence: true),
         website: package_details['html_url']&.strip,
-        dependency: !main_file.include?(package_details['name'])
+        dependency: !manifest_mentions?(main_file, package_details['name'])
       )
     end
 

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'yarn_lock_parser'
 
 require_relative 'base'
@@ -12,18 +13,33 @@ module SOUP
                     UnsupportedFormatError,
                     "Unsupported yarn.lock format at #{file}: only Yarn v1 lockfiles are supported by yarn_lock_parser"
                   )
-      main_file = File.read(sibling_file(file, 'package.json'))
+      main_file_json = JSON.parse(File.read(sibling_file(file, 'package.json')))
+      # Map each declared package.json dependency to its version spec, using
+      # exact names. direct_deps drives the dependency flag; the spec lets us
+      # reject locally vendored packages (file:vendor/...) by exact lookup
+      # instead of a substring scan of the raw package.json text.
+      manifest_deps = manifest_dependency_specs(main_file_json)
+      direct_deps = manifest_deps.keys
 
-      work_items = lock_file.reject { |js_package| main_file.include?("#{js_package[:name]}\": \"file:vendor") }
+      work_items = lock_file.reject { |js_package| manifest_deps[js_package[:name]].to_s.start_with?('file:vendor') }
 
       parallel_each(work_items, packages) do |js_package|
-        fetch_package(file, main_file, js_package)
+        fetch_package(file, direct_deps, js_package)
       end
     end
 
     private
 
-    def fetch_package(file, main_file, js_package)
+    DEPENDENCY_SECTIONS = %w[dependencies devDependencies optionalDependencies peerDependencies].freeze
+    private_constant :DEPENDENCY_SECTIONS
+
+    def manifest_dependency_specs(main_file_json)
+      DEPENDENCY_SECTIONS
+        .filter_map { |section| main_file_json[section] }
+        .reduce({}, :merge)
+    end
+
+    def fetch_package(file, direct_deps, js_package)
       name = js_package[:name]
       version = js_package[:version]
       puts("Checking #{name} #{version}...")
@@ -49,7 +65,7 @@ module SOUP
         license: package_details['license'],
         description: Package.sanitize_description(package_details['description'], strip_markdown: true),
         website: package_details['homepage'],
-        dependency: !main_file.include?(name)
+        dependency: !direct_deps.include?(name)
       )
     end
   end

--- a/spec/soup/bundler_parser_spec.rb
+++ b/spec/soup/bundler_parser_spec.rb
@@ -7,8 +7,13 @@ RSpec.describe(SOUP::BundlerParser) do
     instance_double(Bundler::LazySpecification, name: 'test-gem', version: Gem::Version.new('1.0.0'))
   end
 
-  let(:lock_file)         { instance_double(Bundler::LockfileParser, specs: [spec]) }
-  let(:main_file_content) { "gem 'test-gem'"                                        }
+  # DEPENDENCIES section of the lockfile = the directly declared gems. test-gem
+  # is present here, so it is classified as a direct dependency by default.
+  let(:lock_file) do
+    # rubocop:disable Style/StringHashKeys -- DEPENDENCIES keys are gem-name strings.
+    instance_double(Bundler::LockfileParser, specs: [spec], dependencies: { 'test-gem' => nil })
+    # rubocop:enable Style/StringHashKeys
+  end
 
   let(:v2_response_body) do
     {
@@ -21,8 +26,6 @@ RSpec.describe(SOUP::BundlerParser) do
   before do
     allow(Bundler::LockfileParser).to(receive(:new).and_return(lock_file))
     allow(Bundler).to(receive(:read_file).with('Gemfile.lock').and_return(''))
-    allow(File).to(receive(:read).and_call_original)
-    allow(File).to(receive(:read).with('Gemfile').and_return(main_file_content))
   end
 
   context 'when v2 API succeeds' do
@@ -102,15 +105,42 @@ RSpec.describe(SOUP::BundlerParser) do
     end
   end
 
-  context 'when gem is not in main file' do
-    before do
-      allow(File).to(receive(:read).with('Gemfile').and_return("gem 'other-gem'"))
+  context 'when gem is not a direct dependency' do
+    # test-gem resolved in specs but absent from the DEPENDENCIES section.
+    let(:lock_file) do
+      # rubocop:disable Style/StringHashKeys -- DEPENDENCIES keys are gem-name strings.
+      instance_double(Bundler::LockfileParser, specs: [spec], dependencies: { 'other-gem' => nil })
+      # rubocop:enable Style/StringHashKeys
+    end
 
+    before do
       stub_request(:get, 'https://api.rubygems.org/api/v2/rubygems/test-gem/versions/1.0.0.json')
         .to_return(status: 200, body: v2_response_body)
     end
 
     it 'marks transitive dependencies' do
+      packages = {}
+      parser.parse('Gemfile.lock', packages)
+      expect(packages['test-gem'].dependency).to(be(true))
+    end
+  end
+
+  # BUG-003 regression: a transitive gem whose name is a substring of a direct
+  # dependency (test-gem within test-gem-extras) must NOT be mis-flagged as
+  # direct. The previous String#include? scan of the Gemfile classified it wrong.
+  context 'when a transitive gem name is a substring of a direct dependency' do
+    let(:lock_file) do
+      # rubocop:disable Style/StringHashKeys -- DEPENDENCIES keys are gem-name strings.
+      instance_double(Bundler::LockfileParser, specs: [spec], dependencies: { 'test-gem-extras' => nil })
+      # rubocop:enable Style/StringHashKeys
+    end
+
+    before do
+      stub_request(:get, 'https://api.rubygems.org/api/v2/rubygems/test-gem/versions/1.0.0.json')
+        .to_return(status: 200, body: v2_response_body)
+    end
+
+    it 'classifies the substring gem as transitive' do
       packages = {}
       parser.parse('Gemfile.lock', packages)
       expect(packages['test-gem'].dependency).to(be(true))
@@ -213,7 +243,7 @@ RSpec.describe(SOUP::BundlerParser) do
         instance_double(Bundler::LazySpecification, name: "gem-#{i}", version: Gem::Version.new('1.0.0'))
       end
     end
-    let(:lock_file) { instance_double(Bundler::LockfileParser, specs: specs) }
+    let(:lock_file) { instance_double(Bundler::LockfileParser, specs: specs, dependencies: {}) }
 
     before do
       (1..100).each do |i|

--- a/spec/soup/composer_parser_spec.rb
+++ b/spec/soup/composer_parser_spec.rb
@@ -65,6 +65,24 @@ RSpec.describe(SOUP::ComposerParser) do
     expect(packages['vendor/dev-pkg'].dependency).to(be(true))
   end
 
+  # BUG-003 regression: a transitive package whose name is a substring of a
+  # declared require (vendor/main within vendor/main-pkg) must NOT be flagged
+  # direct. The old String#include? scan of composer.json mis-classified it.
+  context 'when a transitive package name is a substring of a required package' do
+    let(:lock_file) do
+      {
+        packages: [
+          { name: 'vendor/main', version: '1.0.0', license: ['MIT'], description: 'Substring pkg', homepage: '' }
+        ],
+        'packages-dev': []
+      }.to_json
+    end
+
+    it 'classifies the substring package as transitive' do
+      expect(packages['vendor/main'].dependency).to(be(true))
+    end
+  end
+
   context 'with parentheses in license' do
     let(:lock_file) do
       {

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -193,6 +193,26 @@ RSpec.describe(SOUP::GradleParser) do
     end
   end
 
+  # BUG-003 regression: a transitive coordinate whose name is a substring of a
+  # declared dependency (com.example:lib within com.example:library) must NOT be
+  # flagged direct. The old String#include? scan of build.gradle mis-classified
+  # it; manifest_mentions? anchors on a non-identifier boundary.
+  context 'when a transitive coordinate is a substring of a declared dependency' do
+    let(:lock_content) { ["com.example:lib:1.0.0=classpath\n"]   }
+    let(:main_file)    { 'classpath "com.example:library:1.0.0"' }
+
+    before do
+      stub_request(:get, %r{search\.maven\.org/solrsearch/select})
+        .to_return(status: 200, body: maven_response)
+    end
+
+    it 'classifies the substring coordinate as transitive' do
+      packages = {}
+      parser.parse('buildscript-gradle.lockfile', packages)
+      expect(packages['com.example:lib'].dependency).to(be(true))
+    end
+  end
+
   context 'when only build.gradle.kts (Kotlin DSL) exists' do
     before do
       allow(File).to(receive(:read).with('build.gradle').and_raise(Errno::ENOENT))

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -124,6 +124,53 @@ RSpec.describe(SOUP::PIPParser) do
     end
   end
 
+  # BUG-003 regression: a transitive package whose name is a substring of a
+  # declared requirement (requests within requests-oauthlib) must NOT be flagged
+  # direct. The old String#include? scan of requirements.in mis-classified it.
+  context 'when a transitive package name is a substring of a declared requirement' do
+    before do
+      allow(File).to(receive(:exist?).with('requirements.in').and_return(true))
+      allow(File).to(receive(:read).and_call_original)
+      allow(File).to(receive(:read).with('requirements.in').and_return("requests-oauthlib\n"))
+
+      foreach_stub = receive(:foreach).with('requirements.txt')
+      "requests==2.31.0\n".lines.each { |line| foreach_stub.and_yield(line) }
+      allow(File).to(foreach_stub)
+
+      stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+        .to_return(status: 200, body: requests_response)
+    end
+
+    it 'classifies the substring package as transitive' do
+      packages = {}
+      parser.parse('requirements.txt', packages)
+      expect(packages['requests'].dependency).to(be(true))
+    end
+  end
+
+  # The .in / lockfile names are compared with PEP 503 normalization, so a
+  # declared "Flask_Login" still matches the resolved "flask-login".
+  context 'when the declared name differs only by case and separators' do
+    before do
+      allow(File).to(receive(:exist?).with('requirements.in').and_return(true))
+      allow(File).to(receive(:read).and_call_original)
+      allow(File).to(receive(:read).with('requirements.in').and_return("Flask_Login\n"))
+
+      foreach_stub = receive(:foreach).with('requirements.txt')
+      "flask-login==0.6.3\n".lines.each { |line| foreach_stub.and_yield(line) }
+      allow(File).to(foreach_stub)
+
+      stub_request(:get, 'https://pypi.python.org/pypi/flask-login/json')
+        .to_return(status: 200, body: flask_response)
+    end
+
+    it 'classifies the normalized match as a direct dependency' do
+      packages = {}
+      parser.parse('requirements.txt', packages)
+      expect(packages['flask-login'].dependency).to(be(false))
+    end
+  end
+
   context 'when home_page is nil' do
     let(:nil_homepage_response) do
       {

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -73,6 +73,26 @@ RSpec.describe(SOUP::SPMParser) do
     end
   end
 
+  # BUG-003 regression: a transitive package whose repo name is a substring of a
+  # declared package (Alamofire within AlamofireImage) must NOT be flagged
+  # direct. The old String#include? scan of the manifest mis-classified it;
+  # manifest_mentions? anchors on a non-identifier boundary.
+  context 'when a package name is a substring of a declared package' do
+    let(:main_file_content) { '.package(url: "https://github.com/SomeOrg/AlamofireImage.git", from: "1.0.0")' }
+
+    before do
+      stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
+        .to_return(status: 200, body: github_response)
+    end
+
+    it 'classifies the substring package as transitive', :aggregate_failures do
+      packages = {}
+      parser.parse('Package.resolved', packages)
+      expect(packages).to(have_key('Alamofire'))
+      expect(packages['Alamofire'].dependency).to(be(true))
+    end
+  end
+
   context 'when repository has no license' do
     let(:no_license_response) do
       {

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -44,6 +44,25 @@ RSpec.describe(SOUP::YarnParser) do
     end
   end
 
+  # BUG-003 regression: a transitive package whose name is a substring of a
+  # declared dependency (lodash within lodash-es) must NOT be flagged direct.
+  # The old String#include? scan of package.json mis-classified it.
+  context 'when a transitive package name is a substring of a dependency' do
+    let(:parsed_lock) { [{ name: 'lodash', version: '4.17.21' }] }
+    let(:main_file)   { '{"dependencies":{"lodash-es":"^4.17.0"}}' }
+
+    before do
+      stub_request(:get, 'https://registry.npmjs.org/lodash')
+        .to_return(status: 200, body: registry_response)
+    end
+
+    it 'classifies the substring package as transitive' do
+      packages = {}
+      parser.parse('yarn.lock', packages)
+      expect(packages['lodash'].dependency).to(be(true))
+    end
+  end
+
   context 'when package.json has vendor dependency' do
     before do
       allow(File).to(


### PR DESCRIPTION
## Summary

Six parsers decided whether a package was a direct or transitive dependency by
substring-scanning the raw manifest text (`!main_file.include?(name)`). A package
whose name is a substring of another manifest token (e.g. transitive `rake`
matching `rake-compiler`, or `Alamofire` matching `AlamofireImage`) was
mis-classified, flipping the `dependency` flag that drives
`apply_dependency_defaults` — so a transitive package could be forced into manual
prompting (or fail under `--no_prompt`), and a direct package could silently
receive default risk metadata. The NPM parser already avoided this with an
exact-key match; this PR brings the rest in line.

The fix uses the technique that fits each manifest: an exact dependency-name match
where the manifest is structured data, and a token-boundary match where the
manifest is source code that cannot be cheaply parsed into a dependency set.

**Key changes:**

- `base.rb`: add `manifest_mentions?`, a boundary-anchored matcher so a name only
  matches when not flanked by identifier characters.
- `bundler.rb`: classify from the lockfile's `DEPENDENCIES` section
  (`lock_file.dependencies.keys`) instead of scanning the Gemfile.
- `composer.rb`: classify from `require` / `require-dev` keys in `composer.json`.
- `yarn.rb`: classify from `package.json` dependency-section keys; the
  `file:vendor` filter now does an exact spec lookup instead of a text scan.
- `pip.rb`: classify from `requirements.in` names with PEP 503 normalization
  (case- and separator-insensitive); strips extras before comparing.
- `gradle.rb` / `spm.rb`: use `manifest_mentions?` on the `group:artifact`
  coordinate / repo name (their manifests are build scripts / project files).
- Specs: update `bundler_parser_spec` to stub the lockfile `DEPENDENCIES`
  section, and add substring-collision regression tests for bundler, composer,
  yarn, gradle, spm and pip (plus a PEP 503 normalization test for pip).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
