### PR TITLE
Enable bundler cache, sync yamllint ignores, and document dependency classification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
   pull-requests: read
 env:
-  RUBY-BUNDLER-CACHE: 'false'
+  RUBY-BUNDLER-CACHE: true
 concurrency:
   group: build-${{github.ref}}
   cancel-in-progress: true
@@ -201,6 +201,6 @@ jobs:
         GITHUB_TOKEN: "${{secrets.GH_PAT}}"
     - name: RSpec
       shell: bash
-      run: bundle exec rspec
+      run: bundle exec rspec --format documentation
       env:
         GITHUB_TOKEN: "${{secrets.GH_PAT}}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
   pull-requests: read
 env:
-  RUBY-BUNDLER-CACHE: 'false'
+  RUBY-BUNDLER-CACHE: true
 jobs:
   update_dependencies:
     name: Update Dependencies

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,22 +3,30 @@ rules:
   trailing-spaces: disable
   line-length: disable
 ignore: |
-  node_modules/
-  vendor/
+  # ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
   .build/
-  Pods/
-  Carthage/
-  DerivedData/
-  venv/
-  .venv/
   .bundle/
+  .git/
   .gradle/
+  .hg/
   .m2/
-  dist/
-  build/
-  target/
   .npm/
-  .yarn/
   .pnpm/
-  tmp/
-  var/
+  .pytest_cache/
+  .svn/
+  .venv/
+  .yarn/
+  __pycache__/
+  build/
+  Carthage/
+  coverage/
+  DerivedData/
+  dist/
+  env/
+  Libraries/
+  node_modules/
+  Pods/
+  target/
+  vendor/
+  venv/
+  # ghb:excluded-dirs:end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,6 +225,7 @@
 - `build_package(...)`: Constructs a `SOUP::Package` with normalized fields
 - `normalize_license(license)`: Maps Unlicense and URL-style license values to `NOASSERTION`
 - `sibling_file(file, suffix)`: Resolves a sibling manifest path next to a lock file
+- `manifest_mentions?(main_file, token)`: Token-boundary test for whether a dependency is declared directly in a source-code manifest; matches only when `token` is not flanked by identifier characters so a name that is a substring of another coordinate (e.g. `androidx.core:core` vs `androidx.core:core-ktx`) is not misclassified. Used by the Gradle and SPM parsers
 - `lookup_npm_registry_version(payload, name:, version:)`: Extracts a specific version hash from an npm-style registry payload; shared by the NPM and Yarn parsers
 - `http_error_message(response, url:, package:)`: Builds an actionable error message (status code, URL, package, truncated body) for non-2xx responses
 - `NOASSERTION_LICENSE`: Public constant for the `NOASSERTION` license value
@@ -311,6 +312,7 @@
 **Key Components:**
 
 - `parse(file, packages)`: Parses resolved file and fetches package details from GitHub API in parallel via the inherited `parallel_each` helper (`BaseParser`)
+- Resolves the direct-dependency manifest for `Package.resolved` files that are nested inside an Xcode project bundle by trying, in order, a sibling `Package.swift` (or matching `<Name>.swift`), a sibling `<Name>.xcodeproj/project.pbxproj`, and finally the `project.pbxproj` of an enclosing `*.xcodeproj` higher up the tree; the resolved manifest is passed to `manifest_mentions?` to classify direct vs transitive dependencies
 - Supports `GITHUB_TOKEN` environment variable for rate limit handling
 
 **External Dependencies:**
@@ -403,6 +405,18 @@ Validation criteria for SOUP entries: Accuracy (Requirements match actual usage)
    - Checks if license contains any authorized license substring (case-insensitive)
    - Checks if package is in exceptions list
    - Reports error if license is not approved and not `NOASSERTION`
+
+### Direct vs Transitive Dependency Classification Algorithm
+
+**Purpose:** Classifies each detected package as a direct dependency (declared in the project's manifest) or a transitive dependency (pulled in only by other packages), recorded in `SOUP::Package#dependency`.
+
+**Location:** Per-parser, using helpers in `lib/soup/parsers/base.rb` (`SOUP::BaseParser`)
+
+**Implementation:**
+
+1. For parsers whose manifest is structured data that can be parsed into an exact dependency set (Bundler, Composer, NPM, PIP, Yarn), the direct dependency names are read from the manifest (e.g. `Gemfile` dependencies, the sibling `requirements.in`) and matched against package names with an exact-name comparison
+2. For parsers whose manifest is source code that cannot be parsed into an exact set (Gradle build scripts, Swift `Package.swift`/`pbxproj`), `manifest_mentions?(main_file, token)` performs a token-boundary regex match so a name that is a substring of another coordinate is not misclassified
+3. A package is marked transitive (`dependency: true`) when it is not found among the direct dependencies
 
 ### Markdown Sanitization Algorithm
 


### PR DESCRIPTION
## Summary

Tidies up CI configuration and brings the architecture docs in line with the recent direct/transitive dependency classification work. The bundler cache is turned back on in both workflows for faster runs, the yamllint ignore list is replaced with the managed block generated from `config/languages.yaml`, and `docs/architecture.md` now documents the `manifest_mentions?` helper, the SPM nested-manifest resolution, and the dependency classification algorithm.

**Key changes:**

- Enable `RUBY-BUNDLER-CACHE` in `build.yml` and `dependencies.yml` (previously `'false'`)
- Run RSpec with `--format documentation` in `build.yml` for more readable CI output
- Replace the hand-maintained `.yamllint.yml` ignore list with the `ghb:excluded-dirs` managed block (sorted, adds `.git/`, `.hg/`, `.svn/`, `.pytest_cache/`, `__pycache__/`, `coverage/`, `env/`, `Libraries/`)
- Document `manifest_mentions?` token-boundary matching helper in `docs/architecture.md`
- Document SPM `Package.resolved` direct-manifest resolution for Xcode project bundles
- Add a "Direct vs Transitive Dependency Classification Algorithm" section to the architecture docs

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Changes are limited to CI workflow configuration, yamllint settings, and documentation; no application code changed
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified