### PR TITLE
Sync semgrep excluded dirs and bump json gem to 2.19.8

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,6 +1,31 @@
 # Dependency directories
-vendor/
+# ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
+.build/
+.bundle/
+.git/
+.gradle/
+.hg/
+.m2/
+.npm/
+.pnpm/
+.pytest_cache/
+.svn/
+.venv/
+.yarn/
+__pycache__/
+build/
+Carthage/
+coverage/
+DerivedData/
+dist/
+env/
+Libraries/
 node_modules/
+Pods/
+target/
+vendor/
+venv/
+# ghb:excluded-dirs:end
 
 # Test files - Go
 *_test.go
@@ -14,6 +39,10 @@ node_modules/
 **/*.test.ts
 **/*.spec.js
 **/*.spec.ts
+
+# Workflow DSL scripts (Claude Code): not standard modules, validated by the
+# Workflow runtime rather than static analysis
+**/*.workflow.js
 
 # Test directories
 **/test/

--- a/.soup.json
+++ b/.soup.json
@@ -182,7 +182,7 @@
   "json": {
     "language": "Ruby",
     "package": "json",
-    "version": "2.19.7",
+    "version": "2.19.8",
     "license": "Ruby",
     "description": "A JSON implementation as a JRuby extension.",
     "website": "https://github.com/ruby/json",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.7)
+    json (2.19.8)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -17,7 +17,7 @@
 | Ruby | hashdiff | 1.2.1 | MIT | Hashdiff is a diff lib to compute the smallest difference between two hashes | <https://github.com/liufengyun/hashdiff> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | httparty | 0.24.2 | MIT | Makes http fun! Also, makes consuming restful web services dead easy. | <https://github.com/jnunemaker/httparty> | 2026-05-22 | Medium | Makes http fun! Also, makes consuming restful web services dead easy. | Very popular on rubygems.org |
 | Ruby | i18n | 1.14.8 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | json | 2.19.7 | Ruby | A JSON implementation as a JRuby extension. | <https://github.com/ruby/json> | 2026-05-22 | Low | Used to read package manager and cache files. | Very popular on rubygems.org |
+| Ruby | json | 2.19.8 | Ruby | A JSON implementation as a JRuby extension. | <https://github.com/ruby/json> | 2026-05-22 | Low | Used to read package manager and cache files. | Very popular on rubygems.org |
 | Ruby | language_server-protocol | 3.17.0.5 | MIT | A Language Server Protocol SDK | <https://github.com/mtsmfm/language_server-protocol-ruby> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | lint_roller | 1.1.0 | MIT | A plugin specification for linter and formatter rulesets | <https://github.com/standardrb/lint_roller> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | logger | 1.7.0 | Ruby | Provides a simple logging utility for outputting messages. | <https://github.com/ruby/logger> | 2026-05-22 | Low | Dependency | Dependency |


### PR DESCRIPTION
## Summary

Routine build and security maintenance. The `.semgrepignore` excluded-directory list is brought in sync with the canonical set managed by github-build from `config/languages.yaml`, and the `json` gem receives a patch-level update.

**Key changes:**

- Replace the ad-hoc `.semgrepignore` dependency-directory block with the github-build managed `ghb:excluded-dirs` block covering build/cache/dependency directories across Ruby, Node, Python, Java, Swift, and other ecosystems
- Ignore Claude Code Workflow DSL scripts (`**/*.workflow.js`) from semgrep, since they are validated by the Workflow runtime rather than static analysis
- Bump `json` gem from 2.19.7 to 2.19.8 in `Gemfile.lock`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration and dependency-lockfile changes only; no application code paths affected
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified