### PR TITLE
Add Trivy scanner config with managed excluded-dirs block

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,39 @@
+# Trivy scanner configuration
+# https://trivy.dev/latest/docs/references/configuration/config-file/
+#
+# scan.skip-dirs lists directories Trivy ignores. The block between the
+# ghb:excluded-dirs sentinels is managed by github-build from
+# config/languages.yaml -- do not edit it by hand. Add your own project-specific
+# directories OUTSIDE the sentinels (e.g. below the end marker); they are
+# preserved across rebuilds.
+#
+# Vulnerability/CVE IDs to ignore go in .trivyignore, not here.
+scan:
+  skip-dirs:
+    # ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
+    - "**/.build"
+    - "**/.bundle"
+    - "**/.git"
+    - "**/.gradle"
+    - "**/.hg"
+    - "**/.m2"
+    - "**/.npm"
+    - "**/.pnpm"
+    - "**/.pytest_cache"
+    - "**/.svn"
+    - "**/.venv"
+    - "**/.yarn"
+    - "**/__pycache__"
+    - "**/build"
+    - "**/Carthage"
+    - "**/coverage"
+    - "**/DerivedData"
+    - "**/dist"
+    - "**/env"
+    - "**/Libraries"
+    - "**/node_modules"
+    - "**/Pods"
+    - "**/target"
+    - "**/vendor"
+    - "**/venv"
+    # ghb:excluded-dirs:end


### PR DESCRIPTION
## Summary

Adds a `trivy.yaml` configuration file for the Trivy scanner. It defines `scan.skip-dirs` with a `github-build`-managed block (delimited by `ghb:excluded-dirs` sentinels) sourced from `config/languages.yaml`, mirroring the existing `.semgrepignore` and `.yamllint.yml` conventions in this repo. Documentation in the header explains that the sentinel block is auto-managed and that project-specific directories or CVE ignores belong elsewhere (outside the sentinels / in `.trivyignore`).

**Key changes:**

- Add `trivy.yaml` with `scan.skip-dirs` populated from the managed `ghb:excluded-dirs` block (build artifacts, dependency caches, VCS dirs, vendored code, etc.)
- Document the managed-block convention and where to put custom skip-dirs and CVE ignores

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Static scanner configuration file with no executable code
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified