### PR TITLE
Use string include matcher in base_parser http_error_message specs

### DIFF
--- a/spec/soup/base_parser_spec.rb
+++ b/spec/soup/base_parser_spec.rb
@@ -90,13 +90,13 @@ RSpec.describe(SOUP::BaseParser) do
       it 'omits the body section entirely when the body is empty', :aggregate_failures do
         response.body = ''
         message = parser.http_error_message(response, url: 'https://x/y', package: 'p')
-        expect(message).not_to(match(/body=/))
+        expect(message).not_to(include('body='))
         expect(message).to(include('HTTP 503'))
       end
 
       it 'omits the package section when no package is given' do
         message = parser.http_error_message(response, url: 'https://x/y')
-        expect(message).not_to(match(/package=/))
+        expect(message).not_to(include('package='))
       end
 
       it 'truncates a long body to 200 characters' do


### PR DESCRIPTION
## Summary

Tightens two assertions in the `SOUP::BaseParser#http_error_message` specs so they check for the literal `body=` and `package=` tokens instead of treating them as regular expressions. Using `include` avoids the implicit regex interpretation of `match` and makes the intent of the absence checks clearer and less error-prone.

**Key changes:**

- Replace `not_to match(/body=/)` with `not_to include('body=')` in the empty-body spec
- Replace `not_to match(/package=/)` with `not_to include('package=')` in the no-package spec

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified