### PR TITLE
Add importmap and vendored-JS SOUP support with manual entries and coverage gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,23 @@ The following package managers are supported:
 * Bundler (Gemfile.lock)
 * Composer (composer.lock)
 * Gradle (buildscript-gradle.lockfile, gradle.lockfile)
+* Importmap (config/importmap.rb)
 * NPM (package-lock.json)
 * PIP (requirements.txt)
 * SPM (Package.resolved)
 * Yarn (yarn.lock)
 
 Note: CocoaPods (`Podfile.lock`) support was removed pending upstream compatibility. The `cocoapods-core` gem requires `activesupport < 8`, which is incompatible with the ActiveSupport version this project depends on. `Podfile.lock` files are currently skipped silently; support will be reinstated once `cocoapods-core` upgrades.
+
+For Rails projects using importmap-rails, each `pin '<name>', to: '<https…>'` in `config/importmap.rb` is treated as a
+third-party JavaScript SOUP entry; its npm package and version are derived from the CDN URL and looked up on the npm
+registry. Non-http pins (local first-party assets, `@hotwired/*`, vendored `*.js`) are skipped.
+
+Components that no package manager can resolve — vendored files committed to the repo and proprietary/commercial
+components with no public registry entry — are declared in a manual entries file (default `config/soup-manual.json`), a
+JSON array of objects with at least a `package` key (plus optional `language`, `version`, `license`, `description`,
+`website`, `file`, and the verification fields). When `--vendored_globs` is set, the run fails if any file matching those
+globs has no manual entry, so dropping a new vendored library into the repo cannot silently bypass the register.
 
 The soup file is generated in `./docs/soup.md` and a cache file `.soup.json` is used to preserved previously entered
 choices.
@@ -71,16 +82,19 @@ options
                                      Comma separated list of folders to ignore
         --licenses                   Check for open source licenses compliance
         --licenses_file file         Path to authorized licenses file
+        --manual_file file           Path to manually-declared SOUP entries (vendored/proprietary components)
         --markdown_file file         Path to generated markdown file
         --no_prompt                  Do not prompt for missing information and fail immediately
         --skip_bundler               Ignore Ruby/Bundler/Gemfile/Gemfile.lock even if detected
         --skip_composer              Ignore PHP/Composer/composer.json/composer.lock even if detected
         --skip_gradle                Ignore Kotlin/Gradle/build.gradle/buildscript-gradle.lockfile/gradle.lockfile even if detected
+        --skip_importmap             Ignore Rails/importmap config/importmap.rb even if detected
         --skip_npm                   Ignore JS/NPM/package.json/package-lock.json even if detected
         --skip_pip                   Ignore Python/PIP/requirements.txt even if detected
         --skip_spm                   Ignore Swift/SPM/Package.swift/Package.resolved even if detected
         --skip_yarn                  Ignore JS/Yarn/package.json/yarn.lock even if detected
         --soup                       Check for missing information and generate the soup.md file
+        --vendored_globs globs       Comma separated globs of vendored JS files that must each have a manual SOUP entry
         --auto_reply                 Auto reply to questions prompt
     -h, --help                       Show this message
 

--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -13,6 +13,8 @@ require_relative 'parsers/bundler'
 require_relative 'parsers/composer'
 require_relative 'parsers/generic'
 require_relative 'parsers/gradle'
+require_relative 'parsers/importmap'
+require_relative 'parsers/manual'
 require_relative 'parsers/npm'
 require_relative 'parsers/pip'
 require_relative 'parsers/spm'
@@ -27,6 +29,7 @@ module SOUP
     'composer.lock': { parser: ComposerParser, skip: :skip_composer },
     'Gemfile.lock': { parser: BundlerParser, skip: :skip_bundler },
     'gradle.lockfile': { parser: GradleParser, skip: :skip_gradle },
+    'importmap.rb': { parser: ImportmapParser, skip: :skip_importmap },
     'Package.resolved': { parser: SPMParser, skip: :skip_spm },
     'package-lock.json': { parser: NPMParser, skip: :skip_npm },
     # Podfile.lock support removed: cocoapods-core requires activesupport < 8.
@@ -114,6 +117,41 @@ module SOUP
 
           puts("Reading file #{file}...")
           generic_parser.parse(config[:parser].new, file, @detected_packages)
+        end
+      end
+
+      parse_manual_entries
+      enforce_vendored_coverage
+    end
+
+    # Manually-declared SOUP entries cover vendored/proprietary components that
+    # no package manager resolves. Parsed after the auto-detected packages so a
+    # project can override an auto-detected entry by package name if needed.
+    def parse_manual_entries
+      return if @options.manual_file.to_s.empty?
+      return unless File.exist?(@options.manual_file)
+
+      puts("Reading file #{@options.manual_file}...")
+      ManualParser.new.parse(@options.manual_file, @detected_packages)
+    end
+
+    # Fail the run if a committed vendored JS file (matched by --vendored_globs)
+    # has no SOUP entry, so dropping a new third-party file into the repo cannot
+    # silently bypass the register. Coverage is matched on the entry's `file`
+    # path or basename.
+    def enforce_vendored_coverage
+      return if @options.vendored_globs.empty?
+
+      declared = @detected_packages.values.filter_map { |package| package.file unless package.file.to_s.empty? }
+      declared_basenames = declared.map { |path| File.basename(path) }
+
+      @options.vendored_globs.each do |glob|
+        Dir.glob(File.join(Dir.pwd, glob)).each do |file|
+          relative = file.sub("#{Dir.pwd}/", '')
+          next if declared.include?(relative) || declared_basenames.include?(File.basename(file))
+
+          warn("Vendored file #{relative} has no SOUP entry; add it to #{@options.manual_file}!")
+          @exit_code = Status::ERROR_EXIT_CODE
         end
       end
     end

--- a/lib/soup/options.rb
+++ b/lib/soup/options.rb
@@ -14,17 +14,20 @@ module SOUP
       @ignored_folders = []
       @licenses_check = false
       @licenses_file = "#{__dir__}/../../config/licenses.json"
+      @manual_file = './config/soup-manual.json'
       @markdown_file = './docs/soup.md'
       @no_prompt = false
       @parser = OptionParser.new
       @skip_bundler = false
       @skip_composer = false
       @skip_gradle = false
+      @skip_importmap = false
       @skip_npm = false
       @skip_pip = false
       @skip_spm = false
       @skip_yarn = false
       @soup_check = false
+      @vendored_globs = []
 
       setup_parser
     end
@@ -33,10 +36,10 @@ module SOUP
     attr_reader :auto_reply, :licenses_check, :no_prompt, :soup_check
 
     # File-path flags
-    attr_reader :cache_file, :exceptions_file, :licenses_file, :markdown_file, :ignored_folders
+    attr_reader :cache_file, :exceptions_file, :licenses_file, :manual_file, :markdown_file, :ignored_folders, :vendored_globs
 
     # Per-package-manager skip flags
-    attr_reader :skip_bundler, :skip_composer, :skip_gradle, :skip_npm, :skip_pip, :skip_spm, :skip_yarn
+    attr_reader :skip_bundler, :skip_composer, :skip_gradle, :skip_importmap, :skip_npm, :skip_pip, :skip_spm, :skip_yarn
 
     def parse
       @parser.parse!(@argv)
@@ -76,6 +79,10 @@ module SOUP
         @licenses_file = file
       end
 
+      @parser.on('', '--manual_file file', 'Path to manually-declared SOUP entries (vendored/proprietary components)') do |file|
+        @manual_file = file
+      end
+
       @parser.on('', '--markdown_file file', 'Path to generated markdown file') do |file|
         @markdown_file = file
       end
@@ -96,6 +103,10 @@ module SOUP
         @skip_gradle = true
       end
 
+      @parser.on('', '--skip_importmap', 'Ignore Rails/importmap config/importmap.rb even if detected') do
+        @skip_importmap = true
+      end
+
       @parser.on('', '--skip_npm', 'Ignore JS/NPM/package.json/package-lock.json even if detected') do
         @skip_npm = true
       end
@@ -114,6 +125,10 @@ module SOUP
 
       @parser.on('', '--soup', 'Check for missing information and generate the soup.md file') do
         @soup_check = true
+      end
+
+      @parser.on('', '--vendored_globs globs', 'Comma separated globs of vendored JS files that must each have a manual SOUP entry') do |globs|
+        @vendored_globs = globs.split(',')
       end
 
       @parser.on('', '--auto_reply', 'Auto reply to questions prompt') do

--- a/lib/soup/parsers/importmap.rb
+++ b/lib/soup/parsers/importmap.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module SOUP
+  # Parses a Rails importmap pin file (config/importmap.rb). Only pins that
+  # resolve to an http(s) CDN URL are treated as third-party SOUP; pins that map
+  # to a bare local/vendored asset (application, @hotwired/*, *.js files under
+  # vendor/) are first-party or covered by the manual register and are skipped.
+  #
+  # The npm package name and version are derived from the CDN URL (esm.sh,
+  # jspm.io, jsdelivr), then license/description/website are looked up from the
+  # npm registry, reusing the same lookup the NPM parser uses. Unpinned "latest"
+  # pins (no @version in the URL) resolve to the registry's latest dist-tag.
+  class ImportmapParser < BaseParser
+    PIN_REGEX = /\bpin\s+["']([^"']+)["']\s*,\s*to:\s*["']([^"']+)["']/
+    private_constant :PIN_REGEX
+
+    REGISTRY_ROOT = 'https://registry.npmjs.org'
+    private_constant :REGISTRY_ROOT
+
+    def parse(file, packages)
+      work_items =
+        File.foreach(file).filter_map do |line|
+          match = line.match(PIN_REGEX)
+          next unless match
+
+          url = match[2]
+          next unless url.start_with?('http')
+
+          name, version = name_and_version_from_url(url)
+          next if name.nil?
+
+          [name, version]
+        end
+
+      parallel_each(work_items, packages) do |name, version|
+        fetch_package(file, name, version)
+      end
+    end
+
+    private
+
+    # Strip the protocol/host and CDN routing prefixes, then read the npm
+    # package name (scoped or plain) and the optional @version that follows it.
+    def name_and_version_from_url(url)
+      path = url.sub(%r{\Ahttps?://[^/]+/}, '')
+      path = path.sub(%r{\Anpm[:/]}, '')
+      match = path.match(%r{\A(@[^/@]+/[^/@]+|[^/@]+)(?:@([^/]+))?})
+      return [nil, nil] unless match
+
+      [match[1], match[2]]
+    end
+
+    def fetch_package(file, name, version)
+      puts("Checking #{name} #{version || 'latest'}...")
+      url = "#{REGISTRY_ROOT}/#{name}"
+
+      begin
+        response = HttpClient.get(url)
+      rescue Net::OpenTimeout, Net::ReadTimeout => e
+        warn("Skipping #{name}: network timeout after retries (#{e.message}); package omitted from SOUP")
+        return
+      end
+
+      if response.code != 200
+        warn(http_error_message(response, url: url, package: name))
+        return
+      end
+
+      payload = JSON.parse(response.body)
+      resolved_version = version || payload.dig('dist-tags', 'latest')
+      package_details = lookup_npm_registry_version(payload, name: name, version: resolved_version)
+      return if package_details.nil?
+
+      raw_license = package_details['license']
+      license = raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
+
+      build_package(
+        name: name,
+        file: file,
+        language: 'JS',
+        version: resolved_version,
+        license: license,
+        description: Package.sanitize_description(package_details['description'], strip_markdown: true),
+        website: package_details['homepage'],
+        dependency: false
+      )
+    end
+  end
+end

--- a/lib/soup/parsers/manual.rb
+++ b/lib/soup/parsers/manual.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module SOUP
+  # Reads manually-declared SOUP entries from a JSON file (default
+  # config/soup-manual.json). These cover third-party components that no package
+  # manager or registry can resolve: vendored files committed to the repo and
+  # proprietary/commercial components with no public registry entry.
+  #
+  # Each entry is an object: package (required), plus language, version, license,
+  # description, website and an optional `file` path. The `file` path lets the
+  # vendored-file enumerator (Application) match a committed file to its entry.
+  # Verification fields (risk/requirements/reasoning) are filled the same way as
+  # for every other package - from the cache or the prompt.
+  class ManualParser < BaseParser
+    REQUIRED_KEY = 'package'
+    private_constant :REQUIRED_KEY
+
+    def parse(file, packages)
+      entries = JSON.parse(File.read(file))
+
+      raise(InvalidLockfileError, "#{file} must contain a JSON array of entries") unless entries.is_a?(Array)
+
+      entries.each do |entry|
+        valid_entry = entry.is_a?(Hash) && !entry[REQUIRED_KEY].to_s.empty?
+        raise(InvalidLockfileError, "Each entry in #{file} must be an object with a non-empty \"package\"") unless valid_entry
+
+        package = build_entry(file, entry)
+        packages[package.package] = package
+      end
+    end
+
+    private
+
+    def build_entry(file, entry)
+      package = build_package(
+        name: entry[REQUIRED_KEY],
+        file: entry['file'].to_s.empty? ? file : entry['file'],
+        language: entry['language'].to_s.empty? ? 'JS' : entry['language'],
+        version: entry['version'].to_s,
+        license: entry['license'].to_s,
+        description: Package.sanitize_description(entry['description'].to_s, strip_markdown: true).to_s,
+        website: entry['website'].to_s,
+        dependency: false
+      )
+      # Let an entry pre-declare its verification fields so a project can fully
+      # describe a proprietary component in one place; otherwise they fall back
+      # to the cache/prompt like any other package.
+      package.risk_level = entry['risk_level'].to_s
+      package.requirements = entry['requirements'].to_s
+      package.verification_reasoning = entry['verification_reasoning'].to_s
+      package
+    end
+  end
+end

--- a/spec/soup/application_vendored_spec.rb
+++ b/spec/soup/application_vendored_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+# Exercises the manual-entries parser and the vendored-JS coverage gate end to
+# end: a committed vendored file with no SOUP entry must fail the run, and one
+# declared in the manual file must pass.
+RSpec.describe(SOUP::Application) do
+  let(:root) { Dir.mktmpdir('soup-app-') }
+
+  after { FileUtils.rm_rf(root) }
+
+  def write(relative, content)
+    path = File.join(root, relative)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  def run(manual_entries)
+    write('config/licenses.json', '["MIT"]')
+    write('config/exceptions.json', '[]')
+    write('config/soup-manual.json', manual_entries.to_json)
+    write('vendor/javascript/tiptap-pro.js', '// vendored')
+
+    argv = [
+      '--soup',
+      '--auto_reply',
+      '--licenses_file',
+      File.join(root, 'config/licenses.json'),
+      '--exceptions_file',
+      File.join(root, 'config/exceptions.json'),
+      '--manual_file',
+      File.join(root, 'config/soup-manual.json'),
+      '--cache_file',
+      File.join(root, '.soup.json'),
+      '--markdown_file',
+      File.join(root, 'docs/soup.md'),
+      '--vendored_globs',
+      'vendor/javascript/**/*.js',
+      '--skip_bundler',
+      '--skip_composer',
+      '--skip_gradle',
+      '--skip_importmap',
+      '--skip_npm',
+      '--skip_pip',
+      '--skip_spm',
+      '--skip_yarn'
+    ]
+
+    # detect_packages globs Dir.pwd by design, so the gate must run in `root`.
+    Dir.chdir(root) { described_class.new(argv).execute } # rubocop:disable ThreadSafety/DirChdir
+  end
+
+  it 'fails when a vendored JS file has no manual SOUP entry', :aggregate_failures do
+    exit_code = nil
+    expect { exit_code = run([]) }
+      .to(output(/tiptap-pro\.js has no SOUP entry/).to_stderr)
+    expect(exit_code).to(eq(SOUP::Status::ERROR_EXIT_CODE))
+  end
+
+  it 'passes and records the entry when the vendored file is declared', :aggregate_failures do
+    entries = [{ package: 'tiptap-pro', file: 'vendor/javascript/tiptap-pro.js', license: 'MIT', version: '1.0.0' }]
+    exit_code = run(entries)
+    expect(exit_code).to(eq(SOUP::Status::SUCCESS_EXIT_CODE))
+    expect(File.read(File.join(root, 'docs/soup.md'))).to(include('tiptap-pro'))
+  end
+end

--- a/spec/soup/importmap_parser_spec.rb
+++ b/spec/soup/importmap_parser_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe(SOUP::ImportmapParser) do
+  subject(:parser) { described_class.new }
+
+  def registry_body(version, latest: version)
+    {
+      'dist-tags': { latest: latest },
+      versions: {
+        version => {
+          license: 'MIT',
+          description: "desc for #{version}",
+          homepage: 'https://example.com/'
+        }
+      }
+    }.to_json
+  end
+
+  let(:importmap) do
+    <<~RUBY
+      pin 'application'
+      pin 'turbo_confirm', to: 'turbo_confirm.js'
+      pin '@tiptap/starter-kit', to: 'https://esm.sh/@tiptap/starter-kit@3.1.0'
+      pin '@tiptap/pm/state', to: 'https://esm.sh/@tiptap/pm@3.1.0/state'
+      pin 'highlight.js', to: 'https://ga.jspm.io/npm:highlight.js@11.9.0/es/index.js'
+      pin 'tributejs', to: 'https://cdn.jsdelivr.net/npm/tributejs@5.1.3/+esm'
+      pin '@rails/ujs', to: 'https://ga.jspm.io/npm:@rails/ujs@7.0.4/lib/assets/compiled/rails-ujs.js'
+      pin 'yjs', to: 'https://esm.sh/yjs'
+    RUBY
+  end
+
+  let(:file) { write_fixture('config/importmap.rb', importmap) }
+
+  let(:packages) do
+    result = {}
+    parser.parse(file, result)
+    result
+  end
+
+  before do
+    stub_request(:get, 'https://registry.npmjs.org/@tiptap/starter-kit').to_return(status: 200, body: registry_body('3.1.0'))
+    stub_request(:get, 'https://registry.npmjs.org/@tiptap/pm').to_return(status: 200, body: registry_body('3.1.0'))
+    stub_request(:get, 'https://registry.npmjs.org/highlight.js').to_return(status: 200, body: registry_body('11.9.0'))
+    stub_request(:get, 'https://registry.npmjs.org/tributejs').to_return(status: 200, body: registry_body('5.1.3'))
+    stub_request(:get, 'https://registry.npmjs.org/@rails/ujs').to_return(status: 200, body: registry_body('7.0.4'))
+    stub_request(:get, 'https://registry.npmjs.org/yjs').to_return(status: 200, body: registry_body('13.6.0'))
+  end
+
+  it 'skips local and non-http pins', :aggregate_failures do
+    expect(packages).not_to(have_key('application'))
+    expect(packages).not_to(have_key('turbo_confirm'))
+  end
+
+  it 'derives scoped name and version from an esm.sh url', :aggregate_failures do
+    pkg = packages['@tiptap/starter-kit']
+    expect(pkg.version).to(eq('3.1.0'))
+    expect(pkg.language).to(eq('JS'))
+    expect(pkg.license).to(eq('MIT'))
+    expect(pkg.dependency).to(be(false))
+  end
+
+  it 'maps a scoped subpath pin to its base package', :aggregate_failures do
+    expect(packages).to(have_key('@tiptap/pm'))
+    expect(packages['@tiptap/pm'].version).to(eq('3.1.0'))
+  end
+
+  it 'derives name and version from jspm npm: and jsdelivr npm/ urls', :aggregate_failures do
+    expect(packages['highlight.js'].version).to(eq('11.9.0'))
+    expect(packages['tributejs'].version).to(eq('5.1.3'))
+    expect(packages['@rails/ujs'].version).to(eq('7.0.4'))
+  end
+
+  it 'resolves an unpinned pin to the registry latest dist-tag' do
+    expect(packages['yjs'].version).to(eq('13.6.0'))
+  end
+
+  context 'with a non-200 response' do
+    let(:importmap) { "pin 'marked', to: 'https://esm.sh/marked@12.0.0'\n" }
+
+    before { stub_request(:get, 'https://registry.npmjs.org/marked').to_return(status: 404, body: 'Not Found') }
+
+    it 'skips the package' do
+      expect(packages).to(be_empty)
+    end
+  end
+
+  context 'when the version is absent from the registry' do
+    let(:importmap) { "pin 'marked', to: 'https://esm.sh/marked@99.0.0'\n" }
+
+    before { stub_request(:get, 'https://registry.npmjs.org/marked').to_return(status: 200, body: registry_body('12.0.0')) }
+
+    it 'warns and omits the package', :aggregate_failures do
+      expect { packages }
+        .to(output(/version not present/).to_stderr)
+      expect(packages).to(be_empty)
+    end
+  end
+end

--- a/spec/soup/manual_parser_spec.rb
+++ b/spec/soup/manual_parser_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe(SOUP::ManualParser) do
+  subject(:parser) { described_class.new }
+
+  let(:entries) do
+    [
+      {
+        package: 'tiptap-pro',
+        file: 'vendor/javascript/tiptap-pro.js',
+        language: 'JS',
+        version: '1.0.0',
+        license: 'Commercial',
+        description: 'Tiptap Pro toolkit',
+        website: 'https://tiptap.dev/',
+        risk_level: 'Low',
+        requirements: 'Editor toolkit',
+        verification_reasoning: 'Commercial subscription'
+      },
+      {
+        package: 'prismjs',
+        file: 'app/javascript/prism.js',
+        version: '1.30.0',
+        license: 'MIT'
+      }
+    ]
+  end
+
+  let(:file) { write_fixture('config/soup-manual.json', entries.to_json) }
+
+  let(:packages) do
+    result = {}
+    parser.parse(file, result)
+    result
+  end
+
+  it 'builds packages for each declared entry', :aggregate_failures do
+    expect(packages.keys).to(contain_exactly('tiptap-pro', 'prismjs'))
+    expect(packages['tiptap-pro'].license).to(eq('Commercial'))
+    expect(packages['tiptap-pro'].file).to(eq('vendor/javascript/tiptap-pro.js'))
+    expect(packages['tiptap-pro'].dependency).to(be(false))
+  end
+
+  it 'carries pre-declared verification fields through', :aggregate_failures do
+    expect(packages['tiptap-pro'].risk_level).to(eq('Low'))
+    expect(packages['tiptap-pro'].verification_reasoning).to(eq('Commercial subscription'))
+  end
+
+  it 'defaults language to JS when unspecified' do
+    expect(packages['prismjs'].language).to(eq('JS'))
+  end
+
+  context 'when the file is not a JSON array' do
+    let(:file) { write_fixture('config/soup-manual.json', '{}') }
+
+    it 'raises' do
+      expect { packages }
+        .to(raise_error(SOUP::InvalidLockfileError, /must contain a JSON array/))
+    end
+  end
+
+  context 'when an entry has no package name' do
+    let(:file) { write_fixture('config/soup-manual.json', [{ version: '1.0.0' }].to_json) }
+
+    it 'raises' do
+      expect { packages }
+        .to(raise_error(SOUP::InvalidLockfileError, /non-empty/))
+    end
+  end
+end

--- a/spec/soup/options_spec.rb
+++ b/spec/soup/options_spec.rb
@@ -138,5 +138,24 @@ RSpec.describe(SOUP::Options) do
       expect { described_class.new(['--unknown_flag']).parse }
         .to(raise_error(OptionParser::InvalidOption))
     end
+
+    context 'with importmap and vendored JS options' do
+      let(:parsed) do
+        described_class.new(['--skip_importmap', '--manual_file', 'm.json', '--vendored_globs', 'a/*.js,b/c.js']).parse
+      end
+
+      it 'defaults the manual file, skip_importmap and vendored globs', :aggregate_failures do
+        options = described_class.new([]).parse
+        expect(options.manual_file).to(eq('./config/soup-manual.json'))
+        expect(options.skip_importmap).to(be(false))
+        expect(options.vendored_globs).to(eq([]))
+      end
+
+      it 'parses --skip_importmap, --manual_file and --vendored_globs', :aggregate_failures do
+        expect(parsed.skip_importmap).to(be(true))
+        expect(parsed.manual_file).to(eq('m.json'))
+        expect(parsed.vendored_globs).to(eq(['a/*.js', 'b/c.js']))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Extends the SOUP register to cover third-party JavaScript in Rails projects that use importmap-rails and/or vendor JS directly. Previously the tool only discovered package-manager lockfiles (Gemfile.lock, package-lock.json, …), so importmap CDN pins and vendored `.js` files were invisible to the SOUP/license process. Driven by Cloud-Officer/compliance#597 (finding DEP-002).

**Key changes:**

- **`ImportmapParser`** (`lib/soup/parsers/importmap.rb`): parses `config/importmap.rb`, treats each `pin '<name>', to: '<https…>'` as a third-party JS component, derives the npm package + version from the CDN URL (esm.sh, jspm.io, jsdelivr — scoped names, subpath pins like `@tiptap/pm/state`, and `npm:`/`npm/` prefixes handled), and looks up license/description/website on the npm registry (reusing the NPM parser's helper). Unpinned "latest" pins resolve to the registry `latest` dist-tag. Non-http pins (local/first-party, `@hotwired/*`, vendored `*.js`) are skipped.
- **`ManualParser`** (`lib/soup/parsers/manual.rb`): reads a JSON array of manually-declared SOUP entries (default `config/soup-manual.json`) for components no registry can resolve — vendored files and proprietary/commercial components. Each entry needs at least a `package`; optional `language`, `version`, `license`, `description`, `website`, `file`, and the verification fields.
- **Vendored-coverage gate** (`Application#enforce_vendored_coverage`): when `--vendored_globs` is set, the run fails (ERROR exit) if any file matching those globs has no manual entry — so dropping a new vendored library into the repo cannot silently bypass the register.
- New flags: `--skip_importmap`, `--manual_file`, `--vendored_globs`; `importmap.rb` registered in `PARSER_REGISTRY`; README updated.

## Validation

Run against a real Rails importmap (`Cloud-Officer/compliance`): the parser discovered all 19 importmap packages (the `@tiptap/pm/state` + `pm/view` pins correctly dedupe to one `@tiptap/pm`), resolving real versions/licenses (`@tiptap/core`→3.26.1, `yjs`→13.6.31, `highlight.js`→BSD-3-Clause, the rest MIT).

## Tests

- `spec/soup/importmap_parser_spec.rb` — URL/version derivation for esm.sh/jspm/jsdelivr, scoped subpath pins, unpinned→latest, skip of non-http/local pins, 404 + missing-version handling (webmock-stubbed registry).
- `spec/soup/manual_parser_spec.rb` — entry building, pre-declared verification fields, defaults, and invalid-input errors.
- `spec/soup/application_vendored_spec.rb` — the coverage gate fails on an undeclared vendored file and passes once it is declared.
- `spec/soup/options_spec.rb` — the three new flags.

Full suite: 250 examples, 0 failures. Coverage 98.48% line / 86.89% branch (both above the 80% gate). Rubocop and markdownlint clean.

## Follow-up

To enforce this in `Cloud-Officer/compliance` CI, this needs a release into `cloud-officer/ci-actions/soup@v2`; the compliance-side data + workflow wiring (closing compliance#597) lands in a separate PR there.