### PR TITLE
Fix #356: PIP parser silently drops requirement lines with inline comments

### DIFF
--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -19,9 +19,11 @@ module SOUP
 
       work_items = []
       File.foreach(file) do |line|
+        # Strip inline/full-line comments first (mirrors read_direct_dependencies)
+        # so pinned packages with trailing comments such as
+        # `requests==2.31.0  # security pin` are not silently dropped.
+        line = line.split('#', 2).first.to_s
         next if line.strip.empty?
-
-        next if line.include?('#')
 
         line = line.slice(0, line.index(';')) if line.include?(';')
         pip_package, version = line.strip.split('==', 2)

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -215,6 +215,33 @@ RSpec.describe(SOUP::PIPParser) do
     end
   end
 
+  # BUG-001 regression: a pinned package carrying a trailing inline comment
+  # (PEP 508 / `pip-compile --annotation-style=line`) must be parsed, not
+  # silently dropped. Before the fix, `next if line.include?('#')` skipped the
+  # whole line; full-line comments must still be skipped via the blank guard.
+  context 'when a requirement line has a trailing inline comment' do
+    before do
+      allow(File).to(
+        receive(:foreach).with('requirements.txt')
+                         .and_yield("# full-line comment\n")
+                         .and_yield("requests==2.31.0  # security pin\n")
+                         .and_yield("flask==3.0.0  # pinned for CVE\n")
+      )
+      stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+        .to_return(status: 200, body: requests_response)
+      stub_request(:get, 'https://pypi.python.org/pypi/flask/json')
+        .to_return(status: 200, body: flask_response)
+    end
+
+    it 'strips the inline comment and parses the package', :aggregate_failures do
+      packages = {}
+      parser.parse('requirements.txt', packages)
+      expect(packages['requests'].version).to(eq('2.31.0'))
+      expect(packages['flask'].version).to(eq('3.0.0'))
+      expect(packages.size).to(eq(2))
+    end
+  end
+
   context 'when license is empty and no classifiers exist' do
     let(:empty_license_response) do
       {


### PR DESCRIPTION
## Summary

`PIPParser#read_lock_file` skipped any requirements.txt line containing a `#` (`next if line.include?('#')`), silently dropping valid pinned packages that carry trailing inline comments (e.g. `requests==2.31.0  # security pin`, as emitted by `pip-compile --annotation-style=line`). The package vanished from the SOUP compliance document with no warning and exit code 0 — the worst failure mode for a report-completeness tool.

The fix strips the comment before the blank-line guard, mirroring how `read_direct_dependencies` already handles `#` via `split('#', 2)`. Inline comments are now stripped and the package processed; full-line comments collapse to empty and fall through the existing blank-line skip.

Fixes #356

**Key changes:**

- `lib/soup/parsers/pip.rb`: replace `next if line.include?('#')` with `line = line.split('#', 2).first.to_s` placed before the empty-line check.
- `spec/soup/pip_parser_spec.rb`: add a BUG-001 regression context covering a trailing inline comment and a full-line comment (fails before the fix, passes after).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified