### PR TITLE
Fix #357: Yarn parser crashes on legacy object-form npm license fields

### DIFF
--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -101,6 +101,17 @@ module SOUP
       package_details
     end
 
+    # Coerce an npm-registry `license` field to a plain string. The registry
+    # returns it as a String ("MIT") for modern packages but as the legacy
+    # object form `{ "type": "MIT", "url": "..." }` for older versions. Left
+    # untouched, a Hash flows through normalize_license and reaches
+    # Application#validate_license, where `license.downcase` raises
+    # NoMethodError and aborts the whole run. Shared by NPM and Yarn parsers,
+    # which consume the identical registry.npmjs.org per-version payload.
+    def npm_registry_license(raw_license)
+      raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
+    end
+
     # Build an actionable error message for a non-2xx response.
     #
     # Includes status code, reason phrase, URL, the package being processed (when

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -44,15 +44,12 @@ module SOUP
       package_details = lookup_npm_registry_version(JSON.parse(response.body), name: name, version: value['version'])
       return if package_details.nil?
 
-      raw_license = package_details['license']
-      license = raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
-
       build_package(
         name: name,
         file: file,
         language: 'JS',
         version: value['version'],
-        license: license,
+        license: npm_registry_license(package_details['license']),
         description: Package.sanitize_description(package_details['description'], strip_markdown: true),
         website: package_details['homepage'],
         dependency: !direct_deps.include?(name)

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -62,7 +62,7 @@ module SOUP
         file: file,
         language: 'JS',
         version: version,
-        license: package_details['license'],
+        license: npm_registry_license(package_details['license']),
         description: Package.sanitize_description(package_details['description'], strip_markdown: true),
         website: package_details['homepage'],
         dependency: !direct_deps.include?(name)

--- a/spec/soup/base_parser_spec.rb
+++ b/spec/soup/base_parser_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe(SOUP::BaseParser) do
                :collect_packages,
                :build_package,
                :normalize_license,
+               :npm_registry_license,
                :http_error_message
       end
     end
@@ -74,6 +75,26 @@ RSpec.describe(SOUP::BaseParser) do
 
       it 'passes through a normal SPDX identifier' do
         expect(parser.normalize_license('MIT')).to(eq('MIT'))
+      end
+    end
+
+    # BUG-002: the npm registry returns `license` as a String for modern
+    # packages but as the legacy object form {"type": "...", "url": "..."} for
+    # older versions. The Hash must be coerced to its type string so it never
+    # reaches Application#validate_license's unguarded `.downcase`.
+    describe '#npm_registry_license' do
+      it 'passes a plain string license through unchanged' do
+        expect(parser.npm_registry_license('MIT')).to(eq('MIT'))
+      end
+
+      it 'extracts the type from the legacy object form' do
+        # String keys mirror the parsed-JSON shape the helper indexes with ['type'].
+        object_license = { 'type' => 'MIT', 'url' => 'https://x/y' } # rubocop:disable Style/StringHashKeys
+        expect(parser.npm_registry_license(object_license)).to(eq('MIT'))
+      end
+
+      it 'returns an empty string for nil so normalize_license stays Hash-free' do
+        expect(parser.npm_registry_license(nil)).to(eq(''))
       end
     end
 

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -185,6 +185,37 @@ RSpec.describe(SOUP::YarnParser) do
     end
   end
 
+  # BUG-002 regression: the npm registry returns the legacy object-form
+  # license {"type": "MIT", "url": "..."} for older package versions. Before
+  # the fix YarnParser passed the Hash straight to build_package, and it later
+  # crashed Application#validate_license's `license.downcase` with
+  # NoMethodError, aborting the whole scan. NPMParser already guarded this.
+  context 'when the registry returns the legacy object-form license' do
+    let(:object_license_response) do
+      {
+        versions: {
+          '4.17.21': {
+            license: { type: 'MIT', url: 'https://github.com/lodash/lodash/blob/master/LICENSE' },
+            description: 'Lodash',
+            homepage: 'https://lodash.com/'
+          }
+        }
+      }.to_json
+    end
+
+    before do
+      stub_request(:get, 'https://registry.npmjs.org/lodash')
+        .to_return(status: 200, body: object_license_response)
+    end
+
+    it 'normalizes the object form to its type string instead of crashing', :aggregate_failures do
+      packages = {}
+      expect { parser.parse('yarn.lock', packages) }
+        .not_to(raise_error)
+      expect(packages['lodash'].license).to(eq('MIT'))
+    end
+  end
+
   # TEST-05: race where Dir.glob found the lockfile but it was deleted /
   # unreadable before YarnLockParser::Parser.parse ran.
   context 'when yarn.lock cannot be read' do


### PR DESCRIPTION
## Summary

The npm registry returns the `license` field as a plain string ("MIT") for modern packages but as the legacy object form `{"type": "MIT", "url": "..."}` for older versions. `YarnParser#fetch_package` passed that value straight into `build_package`; `normalize_license` lets a non-empty Hash through untouched, so the Hash reached `Application#validate_license` where `license.downcase` raised `NoMethodError` and aborted the entire scan. `NPMParser` already guarded this inline, but `YarnParser` — which consumes the identical registry payload — did not.

This hoists the coercion into a shared `BaseParser#npm_registry_license` helper (next to the already-shared `lookup_npm_registry_version`) and routes both npm-registry parsers through it, removing the duplicated inline logic in `NPMParser`.

Fixes #357

**Key changes:**

- `lib/soup/parsers/base.rb`: add `npm_registry_license`, coercing the object form to its `type` string (and any value to a string).
- `lib/soup/parsers/yarn.rb`: normalize the license via the shared helper (the bug fix).
- `lib/soup/parsers/npm.rb`: use the shared helper instead of the duplicated inline `is_a?(Hash)` check.
- `spec/soup/yarn_parser_spec.rb`: BUG-002 regression — object-form license normalizes to `MIT` (fails before the fix, passes after).
- `spec/soup/base_parser_spec.rb`: unit-test the new helper (string passthrough, object-form extraction, nil → empty string).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified