### PR TITLE
Update CI workflows, docs, and dependencies for importmap/manual SOUP

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -40,10 +40,12 @@ jobs:
           exit 0
         fi
 
-        # Collect @handles only from the catch-all (*) line — the repo-wide code owners
+        # Collect @handles only from the catch-all (*) line — the repo-wide code owners.
+        # `|| true` keeps the pipeline from aborting under `set -euo pipefail` when there
+        # is no `*` line (grep exits 1); empty handles then degrade to is_owner=false below.
         handles=$(grep -E '^\*\s' "$CODEOWNERS" \
           | grep -oE '@[A-Za-z0-9_.\-]+(/[A-Za-z0-9_.\-]+)?' \
-          | sort -u)
+          | sort -u || true)
 
         is_owner=false
         for h in $handles; do
@@ -71,7 +73,6 @@ jobs:
       env:
         GH_TOKEN: "${{secrets.GH_PAT}}"
         AUTHOR: "${{github.event.pull_request.user.login}}"
-        ORG: "${{github.repository_owner}}"
     - name: Approve PR
       shell: bash
       if: steps.check.outputs.is_owner == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1'}}"
     timeout-minutes: 30
     steps:
     - name: Semgrep
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1'}}"
     timeout-minutes: 30
     steps:
     - name: Trivy

--- a/.soup.json
+++ b/.soup.json
@@ -62,7 +62,7 @@
   "concurrent-ruby": {
     "language": "Ruby",
     "package": "concurrent-ruby",
-    "version": "1.3.6",
+    "version": "1.3.7",
     "license": "MIT",
     "description": "Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more.",
     "website": "http://www.concurrent-ruby.com",
@@ -170,7 +170,7 @@
   "i18n": {
     "language": "Ruby",
     "package": "i18n",
-    "version": "1.14.8",
+    "version": "1.15.0",
     "license": "MIT",
     "description": "New wave Internationalization support for Ruby.",
     "website": "https://github.com/ruby-i18n/i18n",
@@ -458,7 +458,7 @@
   "rubocop": {
     "language": "Ruby",
     "package": "rubocop",
-    "version": "1.87.0",
+    "version": "1.88.0",
     "license": "MIT",
     "description": "RuboCop is a Ruby code style checking and code formatting tool.",
     "website": "https://rubocop.org/",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
@@ -33,7 +33,7 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.8)
+    i18n (1.15.0)
       concurrent-ruby (~> 1.0)
     json (2.19.9)
     language_server-protocol (3.17.0.5)
@@ -79,7 +79,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.87.0)
+    rubocop (1.88.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,10 +43,10 @@
 │  │  Bundler   │ │  Composer  │ │   Gradle   │ │    NPM     │ │    PIP     │ │
 │  │  (Ruby)    │ │   (PHP)    │ │  (Kotlin)  │ │   (JS)     │ │  (Python)  │ │
 │  └────────────┘ └────────────┘ └────────────┘ └────────────┘ └────────────┘ │
-│  ┌────────────┐ ┌────────────┐                                              │
-│  │    SPM     │ │    Yarn    │                                              │
-│  │  (Swift)   │ │   (JS)     │                                              │
-│  └────────────┘ └────────────┘                                              │
+│  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐                │
+│  │    SPM     │ │    Yarn    │ │ Importmap  │ │   Manual   │                │
+│  │  (Swift)   │ │   (JS)     │ │  (Rails)   │ │ (vendored) │                │
+│  └────────────┘ └────────────┘ └────────────┘ └────────────┘                │
 └─────────────────────────────────────────────────────────────────────────────┘
                                       │
                                       ▼
@@ -74,7 +74,7 @@
 2. **Application** (`lib/soup/application.rb`): Orchestrates the entire workflow from detection to output generation
 3. **Options** (`lib/soup/options.rb`): Parses command-line arguments and configures application behavior
 4. **Package** (`lib/soup/package.rb`): Data structure representing a third-party dependency with all IEC 62304 required metadata
-5. **Parsers** (`lib/soup/parsers/`): Language-specific parsers that read lock files and fetch metadata from package registries; each inherits shared fetching, normalization, and parallelization logic from `SOUP::BaseParser`
+5. **Parsers** (`lib/soup/parsers/`): Language-specific parsers that read lock files and fetch metadata from package registries; each inherits shared fetching, normalization, and parallelization logic from `SOUP::BaseParser`. The `ImportmapParser` resolves CDN-pinned dependencies from a Rails `config/importmap.rb`, and the `ManualParser` reads manually-declared entries for vendored/proprietary components that no registry can resolve
 6. **Status** (`lib/soup/status.rb`): Defines exit codes for the application
 7. **Errors** (`lib/soup/errors.rb`): Defines the `SOUP::Error` exception hierarchy raised throughout the application
 
@@ -102,7 +102,9 @@
 - `initialize(argv)`: Configures options and initializes state
 - `execute`: Main entry point that runs the detection, checking, and output workflow. Uses an `ensure` block to persist partial state on failure
 - `validate_config!`: Validates that configuration files exist and contain valid JSON
-- `detect_packages`: Scans for lock files and invokes appropriate parsers
+- `detect_packages`: Scans for lock files and invokes appropriate parsers, then runs `parse_manual_entries` and `enforce_vendored_coverage`
+- `parse_manual_entries`: Invokes `ManualParser` on the manual entries file (default `config/soup-manual.json`) when it exists; parsed after auto-detected packages so a project can override an auto-detected entry by package name
+- `enforce_vendored_coverage`: Fails the run (sets the error exit code) when a committed file matched by `--vendored_globs` has no SOUP entry, matched on the entry's `file` path or basename
 - `read_cached_packages`: Loads previously entered user choices from cache
 - `check_packages`: Validates licenses and prompts for missing IEC 62304 metadata
 - `save_files`: Writes cache and markdown documentation files
@@ -131,8 +133,8 @@
 **Key Components:**
 
 - `parse`: Parses command-line arguments and returns configured options object
-- Configuration attributes: `cache_file`, `markdown_file`, `licenses_file`, `exceptions_file`, `ignored_folders`
-- Skip flags: `skip_bundler`, `skip_composer`, `skip_gradle`, `skip_npm`, `skip_pip`, `skip_spm`, `skip_yarn`
+- Configuration attributes: `cache_file`, `markdown_file`, `licenses_file`, `exceptions_file`, `manual_file`, `ignored_folders`, `vendored_globs`
+- Skip flags: `skip_bundler`, `skip_composer`, `skip_gradle`, `skip_importmap`, `skip_npm`, `skip_pip`, `skip_spm`, `skip_yarn`
 - Mode flags: `licenses_check`, `soup_check`, `no_prompt`, `auto_reply`
 
 **External Dependencies:**
@@ -334,6 +336,31 @@
 - `parallel`
 - `yarn_lock_parser`
 
+### SOUP::ImportmapParser
+
+**Purpose:** Parses a Rails importmap pin file (`config/importmap.rb`) and treats CDN-pinned dependencies as third-party SOUP, fetching metadata from the NPM registry.
+
+**Location:** `lib/soup/parsers/importmap.rb`
+
+**Key Components:**
+
+- `parse(file, packages)`: Reads `pin` directives, keeps only pins that resolve to an http(s) CDN URL (esm.sh, jspm.io, jsdelivr), derives the npm package name and version from the URL, and fetches metadata in parallel via the inherited `parallel_each` helper (`BaseParser`). Local/vendored pins (e.g. `application`, `@hotwired/*`, `*.js` under `vendor/`) are skipped. Unpinned "latest" pins resolve to the registry's latest dist-tag
+- `PIN_REGEX`: Private constant matching `pin "name", to: "url"` directives
+- Reuses `lookup_npm_registry_version` (`BaseParser`) for registry payload extraction
+
+### SOUP::ManualParser
+
+**Purpose:** Reads manually-declared SOUP entries from a JSON file (default `config/soup-manual.json`) for vendored files and proprietary/commercial components that no package manager or registry can resolve.
+
+**Location:** `lib/soup/parsers/manual.rb`
+
+**Key Components:**
+
+- `parse(file, packages)`: Parses a JSON array of entry objects, raising `InvalidLockfileError` if the file is not an array or an entry lacks a non-empty `package`; each entry becomes a `SOUP::Package`
+- Each entry supports `package` (required), plus optional `language`, `version`, `license`, `description`, `website`, and `file`; the `file` path lets the vendored-file coverage check (`Application#enforce_vendored_coverage`) match a committed file to its entry
+- Entries may pre-declare verification fields (`risk_level`, `requirements`, `verification_reasoning`); otherwise they fall back to the cache or prompt like any other package
+- `REQUIRED_KEY`: Private constant for the required `package` field
+
 ## Software of Unknown Provenance
 
 See [soup.md](soup.md) for the complete list of third-party dependencies. The `soup.md` file is auto-generated by the `soup` tool itself; never edit it directly. All metadata is sourced from `.soup.json` (cache) and the lock files at the project root.
@@ -417,6 +444,19 @@ Validation criteria for SOUP entries: Accuracy (Requirements match actual usage)
 1. For parsers whose manifest is structured data that can be parsed into an exact dependency set (Bundler, Composer, NPM, PIP, Yarn), the direct dependency names are read from the manifest (e.g. `Gemfile` dependencies, the sibling `requirements.in`) and matched against package names with an exact-name comparison
 2. For parsers whose manifest is source code that cannot be parsed into an exact set (Gradle build scripts, Swift `Package.swift`/`pbxproj`), `manifest_mentions?(main_file, token)` performs a token-boundary regex match so a name that is a substring of another coordinate is not misclassified
 3. A package is marked transitive (`dependency: true`) when it is not found among the direct dependencies
+
+### Vendored Coverage Enforcement Algorithm
+
+**Purpose:** Ensures that committed vendored JS files cannot silently bypass the SOUP register by requiring each one to have a corresponding entry.
+
+**Location:** `lib/soup/application.rb` in `enforce_vendored_coverage` method
+
+**Implementation:**
+
+1. Returns early when no `--vendored_globs` are configured
+2. Collects the `file` paths (and their basenames) declared by detected/manual packages
+3. For each glob, expands matching files under the project root
+4. Reports an error and sets the error exit code for any matched file whose relative path or basename is not declared, instructing the user to add it to the manual entries file
 
 ### Markdown Sanitization Algorithm
 
@@ -504,3 +544,5 @@ Recoverable failures raise a subclass of `SOUP::Error` (`lib/soup/errors.rb`); t
 | CI/CD mode | `--no_prompt` flag for non-interactive execution |
 | Selective parsing | Skip flags allow excluding specific package managers |
 | Folder exclusion | `--ignored_folders` allows excluding directories from scanning |
+| Vendored coverage gate | `--vendored_globs` fails the run when a committed vendored file has no SOUP entry |
+| Manual SOUP entries | `--manual_file` declares vendored/proprietary components with no registry source |

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -7,7 +7,7 @@
 | Ruby | ast | 2.4.3 | MIT | A library for working with Abstract Syntax Trees. | <https://whitequark.github.io/ast/> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | base64 | 0.3.0 | Ruby | Support for encoding and decoding binary data using a Base64 representation. | <https://github.com/ruby/base64> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | bigdecimal | 4.1.2 | Ruby | This library provides arbitrary-precision decimal floating-point number class. | <https://github.com/ruby/bigdecimal> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | concurrent-ruby | 1.3.6 | MIT | Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. | <http://www.concurrent-ruby.com> | 2026-05-22 | Low | Dependency | Dependency |
+| Ruby | concurrent-ruby | 1.3.7 | MIT | Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. | <http://www.concurrent-ruby.com> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | connection_pool | 3.0.2 | MIT | Generic connection pool for Ruby | <https://github.com/mperham/connection_pool> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | crack | 1.0.1 | MIT | Really simple JSON and XML parsing, ripped from Merb and Rails. | <https://github.com/jnunemaker/crack> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | csv | 3.3.5 | Ruby | The CSV library provides a complete interface to CSV files and data | <https://github.com/ruby/csv> | 2026-05-22 | Low | Dependency | Dependency |
@@ -16,7 +16,7 @@
 | Ruby | drb | 2.2.3 | Ruby | Distributed object system for Ruby | <https://github.com/ruby/drb> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | hashdiff | 1.2.1 | MIT | Hashdiff is a diff lib to compute the smallest difference between two hashes | <https://github.com/liufengyun/hashdiff> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | httparty | 0.24.2 | MIT | Makes http fun! Also, makes consuming restful web services dead easy. | <https://github.com/jnunemaker/httparty> | 2026-05-22 | Medium | Makes http fun! Also, makes consuming restful web services dead easy. | Very popular on rubygems.org |
-| Ruby | i18n | 1.14.8 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2026-05-22 | Low | Dependency | Dependency |
+| Ruby | i18n | 1.15.0 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | json | 2.19.9 | Ruby | This is a JSON implementation as a Ruby extension in C. | <https://github.com/ruby/json> | 2026-05-22 | Low | Used to read package manager and cache files. | Very popular on rubygems.org |
 | Ruby | language_server-protocol | 3.17.0.5 | MIT | A Language Server Protocol SDK | <https://github.com/mtsmfm/language_server-protocol-ruby> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | lint_roller | 1.1.0 | MIT | A plugin specification for linter and formatter rulesets | <https://github.com/standardrb/lint_roller> | 2026-05-22 | Low | Dependency | Dependency |
@@ -40,7 +40,7 @@
 | Ruby | rspec-expectations | 3.13.5 | MIT | rspec-expectations provides a simple, readable API to express expected outcomes of a code example. | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rspec-mocks | 3.13.8 | MIT | RSpec's 'test double' framework, with support for stubbing and mocking | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rspec-support | 3.13.7 | MIT | Support utilities for RSpec gems | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | rubocop | 1.87.0 | MIT | RuboCop is a Ruby code style checking and code formatting tool. | <https://rubocop.org/> | 2026-05-22 | Low | Ruby linter | Most popular gem on rubygems |
+| Ruby | rubocop | 1.88.0 | MIT | RuboCop is a Ruby code style checking and code formatting tool. | <https://rubocop.org/> | 2026-05-22 | Low | Ruby linter | Most popular gem on rubygems |
 | Ruby | rubocop-ast | 1.49.1 | MIT | RuboCop's Node and NodePattern classes. | <https://www.rubocop.org/> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rubocop-capybara | 2.23.0 | MIT | Code style checking for Capybara test files (RSpec, Cucumber, Minitest). | <https://github.com/rubocop/rubocop-capybara> | 2026-05-22 | Low | Ruby linter | Most popular gem |
 | Ruby | rubocop-graphql | 1.6.0 | MIT | A collection of RuboCop cops to improve GraphQL-related code | <https://github.com/DmitryTsepelev/rubocop-graphql> | 2026-05-22 | Low | Ruby linter | Most popular gem |


### PR DESCRIPTION
## Summary

This change brings the repository's CI configuration, documentation, and locked dependencies up to date following the addition of importmap and vendored/manual SOUP support. The architecture docs now describe the new parsers and the vendored-coverage gate, the linter jobs run on all triggering events rather than pull requests only, and the auto-approve workflow is hardened against `set -euo pipefail` aborts.

**Key changes:**

- Document `SOUP::ImportmapParser` and `SOUP::ManualParser`, the `parse_manual_entries`/`enforce_vendored_coverage` application steps, the `--manual_file` and `--vendored_globs` options, the `skip_importmap` flag, and the vendored coverage enforcement algorithm in `docs/architecture.md`; update the parser diagram to include Importmap and Manual.
- Run the Semgrep and Trivy linter jobs whenever linters are enabled, instead of restricting them to `pull_request` events (`build.yml`).
- Harden the auto-approve CODEOWNERS handle collection with `|| true` so an absent `*` line degrades to `is_owner=false` under `set -euo pipefail`, and drop the unused `ORG` env var (`auto-approve.yml`).
- Bump `concurrent-ruby`, `i18n`, and `rubocop` in `Gemfile.lock`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Changes are limited to CI workflow YAML, documentation, and dependency lock updates with no application code changes.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified