### PR TITLE
Only print parser output on failure or non-compliance

### DIFF
--- a/lib/soup/parsers/bundler.rb
+++ b/lib/soup/parsers/bundler.rb
@@ -22,7 +22,6 @@ module SOUP
     private
 
     def fetch_package(file, direct_deps, spec)
-      puts("Checking #{spec.name} #{spec.version}...")
       version_url = "https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{spec.version}.json"
       response = HttpClient.get(version_url)
 

--- a/lib/soup/parsers/composer.rb
+++ b/lib/soup/parsers/composer.rb
@@ -16,8 +16,6 @@ module SOUP
       all_packages = (lock_file['packages'] || []) + (lock_file['packages-dev'] || [])
 
       all_packages.each do |php_package|
-        puts("Checking #{php_package['name']} #{php_package['version']}...")
-
         package = build_package(
           name: php_package['name'],
           file: file,

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -65,7 +65,6 @@ module SOUP
     end
 
     def fetch_package(file, main_file, group_id, artifact_id, version)
-      puts("Checking #{group_id}:#{artifact_id} #{version}...")
       last_url = "https://search.maven.org/solrsearch/select?q=g:%22#{group_id}%22+AND+a:%22#{artifact_id}%22+AND+v:%22#{version}%22&rows=1&wt=json"
       response = HttpClient.get(last_url)
 

--- a/lib/soup/parsers/importmap.rb
+++ b/lib/soup/parsers/importmap.rb
@@ -53,7 +53,6 @@ module SOUP
     end
 
     def fetch_package(file, name, version)
-      puts("Checking #{name} #{version || 'latest'}...")
       url = "#{REGISTRY_ROOT}/#{name}"
 
       begin

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -26,7 +26,6 @@ module SOUP
 
     def fetch_package(file, direct_deps, key, value)
       name = key.split('node_modules/').last
-      puts("Checking #{name} #{value['version']}...")
       url = "https://registry.npmjs.org/#{name}"
 
       begin

--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -72,7 +72,6 @@ module SOUP
     end
 
     def fetch_package(file, direct_deps, pip_package, version)
-      puts("Checking #{pip_package} #{version}...")
       url = "https://pypi.python.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json"
       response = HttpClient.get(url)
 

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -92,7 +92,6 @@ module SOUP
     def fetch_package(file, main_file, token, pin)
       pin_id = pin['identity'] || pin['package']
       version = pin_version(pin)
-      puts("Checking #{pin_id} #{version}...")
       url = "https://api.github.com/repos/#{github_repo_path(pin['location'] || pin['repositoryURL'])}"
 
       response =

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -42,7 +42,6 @@ module SOUP
     def fetch_package(file, direct_deps, js_package)
       name = js_package[:name]
       version = js_package[:version]
-      puts("Checking #{name} #{version}...")
       url = "https://registry.npmjs.org/#{name}"
 
       begin


### PR DESCRIPTION
## Summary

The tool printed one `Checking <name> <version>...` line for every library it
inspected, cluttering the output. This removes those per-library progress lines
from all eight parsers so the run stays quiet on success. Failures and
non-compliance are unaffected: invalid licenses and uncovered vendored files
still surface via `warn(...)`, and registry/HTTP errors still raise
`RegistryError` or warn with the HTTP error message.

**Key changes:**

- Removed the `puts("Checking ...")` progress line from the bundler, composer,
  gradle, importmap, npm, pip, spm, and yarn parsers.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Removes log-only output; existing 255-example suite still passes and no behavior changed
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified