### PR TITLE
Update json gem to 2.20.0 and regenerate SOUP files

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -182,9 +182,9 @@
   "json": {
     "language": "Ruby",
     "package": "json",
-    "version": "2.19.9",
+    "version": "2.20.0",
     "license": "Ruby",
-    "description": "This is a JSON implementation as a Ruby extension in C.",
+    "description": "A JSON implementation as a JRuby extension.",
     "website": "https://github.com/ruby/json",
     "last_verified_at": "2026-05-22",
     "risk_level": "Low",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    json (2.19.9)
+    json (2.20.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -17,7 +17,7 @@
 | Ruby | hashdiff | 1.2.1 | MIT | Hashdiff is a diff lib to compute the smallest difference between two hashes | <https://github.com/liufengyun/hashdiff> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | httparty | 0.24.2 | MIT | Makes http fun! Also, makes consuming restful web services dead easy. | <https://github.com/jnunemaker/httparty> | 2026-05-22 | Medium | Makes http fun! Also, makes consuming restful web services dead easy. | Very popular on rubygems.org |
 | Ruby | i18n | 1.15.2 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | json | 2.19.9 | Ruby | This is a JSON implementation as a Ruby extension in C. | <https://github.com/ruby/json> | 2026-05-22 | Low | Used to read package manager and cache files. | Very popular on rubygems.org |
+| Ruby | json | 2.20.0 | Ruby | A JSON implementation as a JRuby extension. | <https://github.com/ruby/json> | 2026-05-22 | Low | Used to read package manager and cache files. | Very popular on rubygems.org |
 | Ruby | language_server-protocol | 3.17.0.5 | MIT | A Language Server Protocol SDK | <https://github.com/mtsmfm/language_server-protocol-ruby> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | lint_roller | 1.1.0 | MIT | A plugin specification for linter and formatter rulesets | <https://github.com/standardrb/lint_roller> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | logger | 1.7.0 | Ruby | Provides a simple logging utility for outputting messages. | <https://github.com/ruby/logger> | 2026-05-22 | Low | Dependency | Dependency |


### PR DESCRIPTION
## Summary

Bumps the `json` gem from 2.19.9 to 2.20.0 and regenerates the SOUP documentation to reflect the new version.

**Key changes:**

- Update `json` to 2.20.0 in `Gemfile.lock`
- Regenerate `.soup.json` and `docs/soup.md` to match the updated dependency

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency version bump only; covered by the existing suite
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
