### PR TITLE
Fall through to POM mirrors when search.maven.org times out

### DIFF
--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'net/http'
 require 'nokogiri'
 
 require_relative 'base'
@@ -66,33 +67,42 @@ module SOUP
 
     def fetch_package(file, main_file, group_id, artifact_id, version)
       last_url = "https://search.maven.org/solrsearch/select?q=g:%22#{group_id}%22+AND+a:%22#{artifact_id}%22+AND+v:%22#{version}%22&rows=1&wt=json"
-      response = HttpClient.get(last_url)
+      # search.maven.org's solrsearch endpoint is chronically flaky and regularly
+      # stops responding entirely (Net::ReadTimeout). When that happens we must
+      # still try the per-repository POM fallbacks below (maven.google.com et al.
+      # serve the Android/AndroidX artifacts that dominate a Gradle scan), so a
+      # dead primary is treated as "no match" rather than aborting the whole run.
+      response = safe_get(last_url)
 
-      parsed = JSON.parse(response.body) if response.code == 200
+      parsed = JSON.parse(response.body) if response&.code == 200
       docs = parsed&.dig('response', 'docs')
 
-      if response.code == 200 && docs&.length == 1
+      resolved = false
+
+      if response&.code == 200 && docs&.length == 1
         license = docs[0]['l']
         description = docs[0]['p']
         website = docs[0]['home_page']
+        resolved = true
       else
         REPOSITORY_URLS.each do |url|
           last_url = "#{url}/#{group_id.tr('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom"
-          response = HttpClient.get(last_url)
+          response = safe_get(last_url)
 
-          next unless response.code == 200
+          next unless response&.code == 200
 
           xml_doc = Nokogiri::XML(response.body)
           xml_doc.remove_namespaces!
           license = xml_doc.xpath('//licenses/license/name').text
           description = xml_doc.xpath('//description').text
           website = xml_doc.xpath('/project/url').text
+          resolved = true
           break
         end
       end
 
-      if response.code != 200
-        warn(http_error_message(response, url: last_url, package: "#{group_id}:#{artifact_id} #{version}"))
+      unless resolved
+        warn(unresolved_message(response, url: last_url, package: "#{group_id}:#{artifact_id} #{version}"))
         return
       end
 
@@ -106,6 +116,28 @@ module SOUP
         website: website,
         dependency: !manifest_mentions?(main_file, "#{group_id}:#{artifact_id}")
       )
+    end
+
+    # HttpClient.get re-raises Net::OpenTimeout/Net::ReadTimeout once its retries
+    # are exhausted. For a multi-mirror parser an unreachable mirror should not
+    # kill the scan (Parallel.map propagates the first exception and aborts every
+    # other in-flight lookup), so we swallow the timeout, warn, and return nil so
+    # the caller falls through to the next source.
+    def safe_get(url)
+      HttpClient.get(url)
+    rescue Net::OpenTimeout, Net::ReadTimeout => e
+      warn("Error: #{e.message}. Skipping #{url} after retries.")
+      nil
+    end
+
+    # Build the "could not resolve this coordinate" warning. With a final
+    # response in hand we surface its status/url/body via http_error_message;
+    # when every source timed out (response is nil) there is no HTTP status to
+    # report, so we note that instead.
+    def unresolved_message(response, url:, package:)
+      return http_error_message(response, url: url, package: package) if response
+
+      "Skipping #{package}: all Maven lookups timed out (last url=#{url})"
     end
   end
 end

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -178,6 +178,59 @@ RSpec.describe(SOUP::GradleParser) do
     end
   end
 
+  # Regression: search.maven.org's solrsearch endpoint chronically stops
+  # responding (Net::ReadTimeout). HttpClient re-raises after its retries, and
+  # that exception used to propagate through Parallel.map and abort the entire
+  # SOUP run. It must instead fall through to the per-repository POM mirrors.
+  context 'when Maven Central search times out' do
+    let(:pom_xml) do
+      <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <project>
+          <licenses>
+            <license>
+              <name>MIT License</name>
+            </license>
+          </licenses>
+          <description>Fallback description</description>
+          <url>https://fallback.example.com</url>
+        </project>
+      XML
+    end
+
+    context 'with a fallback repository that resolves the package' do
+      before do
+        stub_request(:get, %r{search\.maven\.org/solrsearch/select}).to_timeout
+        stub_request(:get, 'https://maven.google.com/com/example/library/1.0.0/library-1.0.0.pom')
+          .to_return(status: 200, body: pom_xml)
+      end
+
+      it 'falls through to the POM mirror instead of aborting', :aggregate_failures do
+        packages = {}
+        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+          .not_to(raise_error)
+        expect(packages['com.example:library'].license).to(eq('MIT License'))
+      end
+    end
+
+    context 'when every source also times out' do
+      before do
+        stub_request(:get, /search\.maven\.org/).to_timeout
+        stub_request(:get, /maven\.google\.com/).to_timeout
+        stub_request(:get, /plugins\.gradle\.org/).to_timeout
+        stub_request(:get, /jitpack\.io/).to_timeout
+        stub_request(:get, /oss\.sonatype\.org/).to_timeout
+      end
+
+      it 'warns and skips the package without raising', :aggregate_failures do
+        packages = {}
+        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+          .to(output(/all Maven lookups timed out/).to_stderr)
+        expect(packages).to(be_empty)
+      end
+    end
+  end
+
   context 'when package is not in main file' do
     before do
       stub_request(:get, %r{search\.maven\.org/solrsearch/select})


### PR DESCRIPTION
## Summary

soup's Gradle parser queried `search.maven.org`'s solrsearch endpoint first for every coordinate and, on a `Net::ReadTimeout`/`Net::OpenTimeout`, let `HttpClient` re-raise once its retries were exhausted. That exception propagated through `Parallel.map` and aborted the entire SOUP run — even though the per-repository POM mirrors (`maven.google.com` et al.) were up and serve the Android/AndroidX artifacts that dominate a Gradle scan. solrsearch is chronically flaky and regularly stops responding entirely, which made `repos.sh` runs on Gradle projects fail outright whenever it did.

**Key changes:**

- `GradleParser#fetch_package` now treats a timed-out primary search as "no match here" and falls through to the mirror list instead of aborting.
- A timed-out individual mirror is skipped like a non-200, so one dead mirror no longer kills the lookup.
- A coordinate that no source resolves is warned and skipped (existing behaviour for non-200) rather than raising and taking every other in-flight lookup down with it.
- Added a `safe_get` helper (swallows timeouts, returns nil) and an `unresolved_message` helper that reports the HTTP status when there is a response and notes an all-sources-timed-out skip when there is not.
- Added 2 regression tests covering the timeout-then-mirror-resolves and every-source-times-out paths.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified