### PR TITLE
#388: query pypi.org instead of the retired pypi.python.org domain

### DIFF
--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -72,7 +72,7 @@ module SOUP
     end
 
     def fetch_package(file, direct_deps, pip_package, version)
-      url = "https://pypi.python.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json"
+      url = "https://pypi.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json"
       response = HttpClient.get(url)
 
       raise(RegistryError, http_error_message(response, url: url, package: "#{pip_package}==#{version}")) unless response.code == 200

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -57,11 +57,11 @@ RSpec.describe(SOUP::PIPParser) do
 
   context 'when parsing all three packages' do
     before do
-      stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+      stub_request(:get, 'https://pypi.org/pypi/requests/json')
         .to_return(status: 200, body: requests_response)
-      stub_request(:get, 'https://pypi.python.org/pypi/flask/json')
+      stub_request(:get, 'https://pypi.org/pypi/flask/json')
         .to_return(status: 200, body: flask_response)
-      stub_request(:get, 'https://pypi.python.org/pypi/boto3/json')
+      stub_request(:get, 'https://pypi.org/pypi/boto3/json')
         .to_return(status: 200, body: boto3_response)
     end
 
@@ -84,7 +84,7 @@ RSpec.describe(SOUP::PIPParser) do
 
     it 'strips extras brackets from package name in URL' do
       packages
-      expect(a_request(:get, 'https://pypi.python.org/pypi/boto3/json')).to(have_been_made)
+      expect(a_request(:get, 'https://pypi.org/pypi/boto3/json')).to(have_been_made)
     end
 
     it 'extracts license from classifiers first' do
@@ -110,9 +110,9 @@ RSpec.describe(SOUP::PIPParser) do
       "requests==2.31.0\nflask==3.0.0\n".lines.each { |line| foreach_stub.and_yield(line) }
       allow(File).to(foreach_stub)
 
-      stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+      stub_request(:get, 'https://pypi.org/pypi/requests/json')
         .to_return(status: 200, body: requests_response)
-      stub_request(:get, 'https://pypi.python.org/pypi/flask/json')
+      stub_request(:get, 'https://pypi.org/pypi/flask/json')
         .to_return(status: 200, body: flask_response)
     end
 
@@ -137,7 +137,7 @@ RSpec.describe(SOUP::PIPParser) do
       "requests==2.31.0\n".lines.each { |line| foreach_stub.and_yield(line) }
       allow(File).to(foreach_stub)
 
-      stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+      stub_request(:get, 'https://pypi.org/pypi/requests/json')
         .to_return(status: 200, body: requests_response)
     end
 
@@ -160,7 +160,7 @@ RSpec.describe(SOUP::PIPParser) do
       "flask-login==0.6.3\n".lines.each { |line| foreach_stub.and_yield(line) }
       allow(File).to(foreach_stub)
 
-      stub_request(:get, 'https://pypi.python.org/pypi/flask-login/json')
+      stub_request(:get, 'https://pypi.org/pypi/flask-login/json')
         .to_return(status: 200, body: flask_response)
     end
 
@@ -185,7 +185,7 @@ RSpec.describe(SOUP::PIPParser) do
 
     before do
       allow(File).to(receive(:foreach).with('requirements.txt').and_yield("simple==1.0.0\n"))
-      stub_request(:get, 'https://pypi.python.org/pypi/simple/json')
+      stub_request(:get, 'https://pypi.org/pypi/simple/json')
         .to_return(status: 200, body: nil_homepage_response)
     end
 
@@ -193,6 +193,28 @@ RSpec.describe(SOUP::PIPParser) do
       packages = {}
       parser.parse('requirements.txt', packages)
       expect(packages['simple'].website).to(be_nil)
+    end
+  end
+
+  # QUAL-003 regression: pypi.python.org was retired in April 2018 and only
+  # answers through a permanent 301 to pypi.org, costing an extra round-trip per
+  # package against the HTTP timeout. Both domains are stubbed here so the
+  # expectation fails on a revert instead of merely erroring on an unregistered
+  # request.
+  context 'when resolving the PyPI registry host' do
+    before do
+      allow(File).to(receive(:foreach).with('requirements.txt').and_yield("requests==2.31.0\n"))
+      stub_request(:get, 'https://pypi.org/pypi/requests/json')
+        .to_return(status: 200, body: requests_response)
+      stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+        .to_return(status: 200, body: requests_response)
+    end
+
+    it 'queries pypi.org and never the retired pypi.python.org domain', :aggregate_failures do
+      packages = {}
+      parser.parse('requirements.txt', packages)
+      expect(a_request(:get, 'https://pypi.org/pypi/requests/json')).to(have_been_made)
+      expect(a_request(:get, 'https://pypi.python.org/pypi/requests/json')).not_to(have_been_made)
     end
   end
 
@@ -210,7 +232,7 @@ RSpec.describe(SOUP::PIPParser) do
       packages = {}
       expect { parser.parse('requirements.txt', packages) }
         .to(output(/only exact `==` version pins are supported/).to_stderr)
-      expect(WebMock).not_to(have_requested(:get, /pypi\.python\.org/))
+      expect(WebMock).not_to(have_requested(:get, /pypi\.org/))
       expect(packages).to(be_empty)
     end
   end
@@ -227,9 +249,9 @@ RSpec.describe(SOUP::PIPParser) do
                          .and_yield("requests==2.31.0  # security pin\n")
                          .and_yield("flask==3.0.0  # pinned for CVE\n")
       )
-      stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+      stub_request(:get, 'https://pypi.org/pypi/requests/json')
         .to_return(status: 200, body: requests_response)
-      stub_request(:get, 'https://pypi.python.org/pypi/flask/json')
+      stub_request(:get, 'https://pypi.org/pypi/flask/json')
         .to_return(status: 200, body: flask_response)
     end
 
@@ -256,7 +278,7 @@ RSpec.describe(SOUP::PIPParser) do
 
     before do
       allow(File).to(receive(:foreach).with('requirements.txt').and_yield("pkg==1.0.0\n"))
-      stub_request(:get, 'https://pypi.python.org/pypi/pkg/json')
+      stub_request(:get, 'https://pypi.org/pypi/pkg/json')
         .to_return(status: 200, body: empty_license_response)
     end
 
@@ -336,7 +358,7 @@ RSpec.describe(SOUP::PIPParser) do
             license: ''
           }
         }.to_json
-        stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
+        stub_request(:get, 'https://pypi.org/pypi/requests/json')
           .to_return(status: 200, body: body)
       end
 
@@ -367,7 +389,7 @@ RSpec.describe(SOUP::PIPParser) do
             license: ''
           }
         }.to_json
-        stub_request(:get, "https://pypi.python.org/pypi/pkg-#{i}/json").to_return(status: 200, body: body)
+        stub_request(:get, "https://pypi.org/pypi/pkg-#{i}/json").to_return(status: 200, body: body)
       end
     end
 


### PR DESCRIPTION
## Summary

`PIPParser` queried the legacy `pypi.python.org` domain, retired in April 2018 when Warehouse launched. It answers today only through a permanent 301 to `pypi.org`, so every PyPI lookup paid an extra redirect round-trip per package — multiplied across the parallel scan and charged against the 5s HTTP timeout — while depending on a legacy alias the PSF could drop at any time.

All 16 spec stubs hardcoded the same legacy domain, so the suite would have kept passing even if the redirect broke in production.

**Key changes:**

- `lib/soup/parsers/pip.rb`: `fetch_package` now builds `https://pypi.org/pypi/<name>/json`
- `spec/soup/pip_parser_spec.rb`: 14 WebMock stubs re-pointed to `pypi.org`
- `spec/soup/pip_parser_spec.rb`: fixed a negative assertion that matched `/pypi\.python\.org/` — after the domain swap it would have passed vacuously, guarding nothing; it now matches `/pypi\.org/`
- `spec/soup/pip_parser_spec.rb`: added a QUAL-003 regression test that stubs **both** domains and asserts `pypi.org` was requested and `pypi.python.org` was not, so a revert fails on an explicit expectation rather than incidentally erroring on an unregistered request

Verified the regression test fails before the fix and passes after. Full suite: 258 examples, 0 failures (line coverage 98.48%, branch 88.27%). RuboCop clean. A live check confirms `pypi.org` returns HTTP 200 with 0 redirects, against 1 redirect for the legacy domain.

Closes #388

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
