### PR TITLE
#387: remove dead nil-parser guard and correct its comment

### DIFF
--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -108,12 +108,10 @@ module SOUP
             next
           end
 
-          # Skip-flag and nil-parser guards come BEFORE the "Reading file" announce
-          # so the user never sees "Reading file X..." for a file that is then
-          # silently dropped (e.g. --skip_yarn, or Podfile.lock whose registry
-          # entry maps to a nil parser).
+          # The skip-flag guard comes BEFORE the "Reading file" announce so the
+          # user never sees "Reading file X..." for a file that is then silently
+          # dropped (e.g. --skip_yarn).
           next if @options.public_send(config[:skip])
-          next if config[:parser].nil?
 
           puts("Reading file #{file}...")
           generic_parser.parse(config[:parser].new, file, @detected_packages)

--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -150,6 +150,26 @@ RSpec.describe(SOUP::Application) do
     '{"require":{"valid/pkg":"^1.0","bad/pkg":"^2.0","excepted-pkg":"^3.0","noassert/pkg":"^4.0"}}'
   end
 
+  # COM-001 regression: detect_packages used to carry a `next if
+  # config[:parser].nil?` guard justified by a Podfile.lock entry that no longer
+  # exists in the registry. The guard was removed as dead code, which is only
+  # safe while every entry maps to a concrete parser: a nil placeholder would
+  # now blow up on `config[:parser].new`. These examples lock that invariant in,
+  # so reintroducing a nil entry fails here instead of at runtime. The registry
+  # is private_constant, hence the module_eval reach-in.
+  describe 'PARSER_REGISTRY' do
+    subject(:registry) { SOUP.module_eval('PARSER_REGISTRY', __FILE__, __LINE__) }
+
+    it 'maps every package file to a concrete parser class, never nil' do
+      expect(registry.reject { |_file, config| config[:parser].is_a?(Class) }).to(be_empty)
+    end
+
+    it 'names a skip option that Options actually defines for every entry' do
+      options = SOUP::Options.new(['--licenses', '--licenses_file', licenses_file.path, '--exceptions_file', exceptions_file.path]).parse
+      expect(registry.reject { |_file, config| options.respond_to?(config[:skip]) }).to(be_empty)
+    end
+  end
+
   describe '#execute' do
     it 'runs successfully with --licenses only and no detected packages' do
       app = described_class.new(licenses_args)


### PR DESCRIPTION
## Summary

`detect_packages` carried a `next if config[:parser].nil?` guard whose comment justified it with "Podfile.lock whose registry entry maps to a nil parser". That entry no longer exists — it was removed because cocoapods-core requires activesupport < 8 (see the comment at `application.rb:35`). Verified at runtime: `PARSER_REGISTRY` holds 9 entries, 0 of them nil, and is both frozen and `private_constant`. The guard was unreachable, and its comment sent readers hunting for a registry entry that isn't there.

Deleting the guard is only safe while every entry maps to a concrete parser — a nil placeholder added later would now crash on `config[:parser].new` instead of being skipped. So the guard is replaced by a test that locks that invariant in.

**Key changes:**

- `lib/soup/application.rb`: removed `next if config[:parser].nil?` and trimmed the comment to the surviving `--skip_yarn` rationale
- `spec/soup/application_spec.rb`: added a `PARSER_REGISTRY` describe block with two examples — every entry maps to a concrete parser class (never nil), and every entry's `skip:` symbol is a method `Options` actually defines (guarding the `public_send` on the line above)

Confirmed the invariant test is not vacuous by injecting a `'Podfile.lock': { parser: nil, skip: :skip_bogus }` entry: both examples failed and named the offending entry, then reverted.

**Note for reviewers:** the issue describes the removed line as "uncoverable dead code". It was in fact a *covered* line — it executed for every registry entry, always evaluating false. What was dead was the branch. That is why branch coverage improved rather than merely holding steady.

Verification: full suite 260 examples, 0 failures; RuboCop clean; line coverage 98.48% (unchanged), branch coverage 88.27% -> 88.56%.

Closes #387

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
