### PR TITLE
#386: use npm_registry_license helper in the importmap parser

### DIFF
--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -106,8 +106,9 @@ module SOUP
     # object form `{ "type": "MIT", "url": "..." }` for older versions. Left
     # untouched, a Hash flows through normalize_license and reaches
     # Application#validate_license, where `license.downcase` raises
-    # NoMethodError and aborts the whole run. Shared by NPM and Yarn parsers,
-    # which consume the identical registry.npmjs.org per-version payload.
+    # NoMethodError and aborts the whole run. Shared by the NPM, Yarn, and
+    # Importmap parsers, which consume the identical registry.npmjs.org
+    # per-version payload.
     def npm_registry_license(raw_license)
       raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
     end

--- a/lib/soup/parsers/importmap.rb
+++ b/lib/soup/parsers/importmap.rb
@@ -72,15 +72,12 @@ module SOUP
       package_details = lookup_npm_registry_version(payload, name: name, version: resolved_version)
       return if package_details.nil?
 
-      raw_license = package_details['license']
-      license = raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
-
       build_package(
         name: name,
         file: file,
         language: 'JS',
         version: resolved_version,
-        license: license,
+        license: npm_registry_license(package_details['license']),
         description: Package.sanitize_description(package_details['description'], strip_markdown: true),
         website: package_details['homepage'],
         dependency: false

--- a/spec/soup/importmap_parser_spec.rb
+++ b/spec/soup/importmap_parser_spec.rb
@@ -84,6 +84,44 @@ RSpec.describe(SOUP::ImportmapParser) do
     end
   end
 
+  # QUAL-002: the npm registry returns `license` as a plain String for modern
+  # packages but as the legacy object form { "type": ..., "url": ... } for older
+  # ones. Importmap consumes the same per-version payload as the NPM and Yarn
+  # parsers, so it must coerce it the same way -- an uncoerced Hash flows through
+  # to Application#validate_license, where `license.downcase` raises NoMethodError
+  # and aborts the entire run. These examples cover the importmap call site, which
+  # previously only ever exercised the String form.
+  context 'when the registry returns a legacy object-form license' do
+    let(:importmap) { "pin 'marked', to: 'https://esm.sh/marked@12.0.0'\n" }
+
+    def licensed_body(license, version = '12.0.0')
+      entry = { description: 'desc', homepage: 'https://example.com/' }
+      entry[:license] = license unless license.nil?
+
+      { 'dist-tags': { latest: version }, versions: { version => entry } }.to_json
+    end
+
+    before do
+      stub_request(:get, 'https://registry.npmjs.org/marked')
+        .to_return(status: 200, body: licensed_body({ type: 'MIT', url: 'https://example.com/LICENSE' }))
+    end
+
+    it 'coerces the object to its type string rather than leaving a Hash', :aggregate_failures do
+      expect(packages['marked'].license).to(eq('MIT'))
+      expect(packages['marked'].license).to(be_a(String))
+    end
+
+    context 'when the registry omits the license entirely' do
+      before do
+        stub_request(:get, 'https://registry.npmjs.org/marked').to_return(status: 200, body: licensed_body(nil))
+      end
+
+      it 'yields an empty string rather than a nil that breaks downstream matching' do
+        expect(packages['marked'].license).to(eq(''))
+      end
+    end
+  end
+
   context 'when the version is absent from the registry' do
     let(:importmap) { "pin 'marked', to: 'https://esm.sh/marked@99.0.0'\n" }
 


### PR DESCRIPTION
## Summary

`ImportmapParser#fetch_package` re-implemented the npm-registry licence coercion inline, character-for-character identical to `BaseParser#npm_registry_license`. Verified the two expressions match exactly before swapping, so this is behaviour-preserving. The helper is `protected` on `BaseParser`, so `ImportmapParser` now calls it the same way the NPM and Yarn parsers already do.

**Key changes:**

- `lib/soup/parsers/importmap.rb`: replaced the inline `raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s` with `npm_registry_license(package_details['license'])`, folded directly into the `build_package` call — the `raw_license` / `license` locals existed only to hold the duplicated logic
- `lib/soup/parsers/base.rb`: helper comment now reads "Shared by the NPM, Yarn, and Importmap parsers", which was previously under-inclusive
- `spec/soup/importmap_parser_spec.rb`: added two examples covering the legacy object-form licence and an omitted licence

**On the added tests.** The issue expected the existing specs to cover this, but the importmap spec only ever exercised the **String** licence form. The legacy object form `{ "type": ..., "url": ... }` — the exact case this helper exists for, and whose mishandling reaches `Application#validate_license` where `license.downcase` raises `NoMethodError` and aborts the whole run — had **zero** coverage on the importmap path. The refactored call site therefore had no test distinguishing correct from broken behaviour.

Both new examples were confirmed load-bearing by temporarily dropping the coercion:

```
expected: "MIT"
     got: {"type" => "MIT", "url" => "https://example.com/LICENSE"}
```

That is precisely the `Hash` that would crash a real run.

Composer, manual, and pip use genuinely different licence logic against non-npm payloads, so they are correctly out of scope.

Verification: full suite 262 examples, 0 failures; RuboCop clean across all 39 files; line coverage 98.47%, branch coverage 88.84% (up from 88.56% — the new cases cover a previously-untaken branch).

Closes #386

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
