### PR TITLE
#385: extract the shared npm-registry fetch flow into BaseParser

### DIFF
--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -14,6 +14,9 @@ module SOUP
     UNLICENSE_PATTERN = 'Unlicense'
     private_constant :UNLICENSE_PATTERN
 
+    NPM_REGISTRY_ROOT = 'https://registry.npmjs.org'
+    private_constant :NPM_REGISTRY_ROOT
+
     def parse(_file, _packages)
       raise(NotImplementedError, "#{self.class} must implement #parse")
     end
@@ -111,6 +114,47 @@ module SOUP
     # per-version payload.
     def npm_registry_license(raw_license)
       raw_license.is_a?(Hash) ? raw_license['type'].to_s : raw_license.to_s
+    end
+
+    # Packument URL for an npm package name.
+    def npm_registry_url(name)
+      "#{NPM_REGISTRY_ROOT}/#{name}"
+    end
+
+    # GET a package's npm packument, absorbing the post-retry timeout that all
+    # three npm consumers (NPM, Yarn, Importmap) treat identically: warn and
+    # omit the package rather than kill the scan. Returns nil in that case, so
+    # callers guard with `return if response.nil?`.
+    #
+    # `label` is what the warning names the package as -- NPM and Yarn know the
+    # version up front and pass "name@version", while Importmap resolves the
+    # version from this very response and so can only name the package.
+    #
+    # Deliberately stops short of the non-200 branch: NPM and Importmap warn and
+    # skip there, Yarn raises RegistryError and aborts the run. Unifying that
+    # split is CONS-001, so each caller keeps its own policy.
+    def npm_registry_response(name:, label: name)
+      HttpClient.get(npm_registry_url(name))
+    rescue Net::OpenTimeout, Net::ReadTimeout => e
+      warn("Skipping #{label}: network timeout after retries (#{e.message}); package omitted from SOUP")
+      nil
+    end
+
+    # Build a Package from an npm-registry per-version payload. The three npm
+    # consumers share the JS language tag and the license/description/website
+    # extraction; they differ only in how the version became known and whether
+    # the package is a direct dependency.
+    def build_npm_registry_package(file:, name:, version:, package_details:, dependency:)
+      build_package(
+        name: name,
+        file: file,
+        language: 'JS',
+        version: version,
+        license: npm_registry_license(package_details['license']),
+        description: Package.sanitize_description(package_details['description'], strip_markdown: true),
+        website: package_details['homepage'],
+        dependency: dependency
+      )
     end
 
     # Build an actionable error message for a non-2xx response.

--- a/lib/soup/parsers/importmap.rb
+++ b/lib/soup/parsers/importmap.rb
@@ -16,9 +16,6 @@ module SOUP
     PIN_REGEX = /\bpin\s+["']([^"']+)["']\s*,\s*to:\s*["']([^"']+)["']/
     private_constant :PIN_REGEX
 
-    REGISTRY_ROOT = 'https://registry.npmjs.org'
-    private_constant :REGISTRY_ROOT
-
     def parse(file, packages)
       work_items =
         File.foreach(file).filter_map do |line|
@@ -53,17 +50,13 @@ module SOUP
     end
 
     def fetch_package(file, name, version)
-      url = "#{REGISTRY_ROOT}/#{name}"
-
-      begin
-        response = HttpClient.get(url)
-      rescue Net::OpenTimeout, Net::ReadTimeout => e
-        warn("Skipping #{name}: network timeout after retries (#{e.message}); package omitted from SOUP")
-        return
-      end
+      # No label override: the version is only known after this response, so the
+      # timeout warning names the package alone.
+      response = npm_registry_response(name: name)
+      return if response.nil?
 
       if response.code != 200
-        warn(http_error_message(response, url: url, package: name))
+        warn(http_error_message(response, url: npm_registry_url(name), package: name))
         return
       end
 
@@ -72,14 +65,11 @@ module SOUP
       package_details = lookup_npm_registry_version(payload, name: name, version: resolved_version)
       return if package_details.nil?
 
-      build_package(
-        name: name,
+      build_npm_registry_package(
         file: file,
-        language: 'JS',
+        name: name,
         version: resolved_version,
-        license: npm_registry_license(package_details['license']),
-        description: Package.sanitize_description(package_details['description'], strip_markdown: true),
-        website: package_details['homepage'],
+        package_details: package_details,
         dependency: false
       )
     end

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -26,31 +26,25 @@ module SOUP
 
     def fetch_package(file, direct_deps, key, value)
       name = key.split('node_modules/').last
-      url = "https://registry.npmjs.org/#{name}"
+      version = value['version']
+      label = "#{name}@#{version}"
 
-      begin
-        response = HttpClient.get(url)
-      rescue Net::OpenTimeout, Net::ReadTimeout => e
-        warn("Skipping #{name}@#{value['version']}: network timeout after retries (#{e.message}); package omitted from SOUP")
-        return
-      end
+      response = npm_registry_response(name: name, label: label)
+      return if response.nil?
 
       if response.code != 200
-        warn(http_error_message(response, url: url, package: "#{name}@#{value['version']}"))
+        warn(http_error_message(response, url: npm_registry_url(name), package: label))
         return
       end
 
-      package_details = lookup_npm_registry_version(JSON.parse(response.body), name: name, version: value['version'])
+      package_details = lookup_npm_registry_version(JSON.parse(response.body), name: name, version: version)
       return if package_details.nil?
 
-      build_package(
-        name: name,
+      build_npm_registry_package(
         file: file,
-        language: 'JS',
-        version: value['version'],
-        license: npm_registry_license(package_details['license']),
-        description: Package.sanitize_description(package_details['description'], strip_markdown: true),
-        website: package_details['homepage'],
+        name: name,
+        version: version,
+        package_details: package_details,
         dependency: !direct_deps.include?(name)
       )
     end

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -42,28 +42,23 @@ module SOUP
     def fetch_package(file, direct_deps, js_package)
       name = js_package[:name]
       version = js_package[:version]
-      url = "https://registry.npmjs.org/#{name}"
+      label = "#{name}@#{version}"
 
-      begin
-        response = HttpClient.get(url)
-      rescue Net::OpenTimeout, Net::ReadTimeout => e
-        warn("Skipping #{name}@#{version}: network timeout after retries (#{e.message}); package omitted from SOUP")
-        return
-      end
+      response = npm_registry_response(name: name, label: label)
+      return if response.nil?
 
-      raise(RegistryError, http_error_message(response, url: url, package: "#{name}@#{version}")) unless response.code == 200
+      # Unlike the NPM and Importmap parsers, a non-200 here aborts the whole
+      # scan rather than skipping the package. CONS-001 tracks unifying that.
+      raise(RegistryError, http_error_message(response, url: npm_registry_url(name), package: label)) unless response.code == 200
 
       package_details = lookup_npm_registry_version(JSON.parse(response.body), name: name, version: version)
       return if package_details.nil?
 
-      build_package(
-        name: name,
+      build_npm_registry_package(
         file: file,
-        language: 'JS',
+        name: name,
         version: version,
-        license: npm_registry_license(package_details['license']),
-        description: Package.sanitize_description(package_details['description'], strip_markdown: true),
-        website: package_details['homepage'],
+        package_details: package_details,
         dependency: !direct_deps.include?(name)
       )
     end

--- a/spec/soup/importmap_parser_spec.rb
+++ b/spec/soup/importmap_parser_spec.rb
@@ -122,6 +122,24 @@ RSpec.describe(SOUP::ImportmapParser) do
     end
   end
 
+  # QUAL-001: the GET + post-retry timeout rescue now lives in
+  # BaseParser#npm_registry_response. Importmap is the one caller that does NOT
+  # pass a `label`, because the version is only resolved from the response it is
+  # still waiting on -- so its warning must name the package alone, with no
+  # "@version" suffix (unlike the NPM and Yarn parsers). This path had no spec
+  # before the extraction.
+  context 'when the registry times out' do
+    let(:importmap) { "pin 'marked', to: 'https://esm.sh/marked@12.0.0'\n" }
+
+    before { stub_request(:get, 'https://registry.npmjs.org/marked').to_timeout }
+
+    it 'skips the package and names it without a version in the warning', :aggregate_failures do
+      expect { packages }
+        .to(output(/Skipping marked: network timeout after retries/).to_stderr)
+      expect(packages).to(be_empty)
+    end
+  end
+
   context 'when the version is absent from the registry' do
     let(:importmap) { "pin 'marked', to: 'https://esm.sh/marked@99.0.0'\n" }
 

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -92,6 +92,15 @@ RSpec.describe(SOUP::NPMParser) do
       expect(packages).to(be_empty)
       expect(a_request(:get, url)).to(have_been_made.times(SOUP::HttpClient.max_retries + 1))
     end
+
+    # QUAL-001: the warning is emitted by the shared
+    # BaseParser#npm_registry_response, which names the package from the `label`
+    # this parser passes. NPM knows the version up front, so it must stay
+    # "name@version" -- Importmap, which cannot, deliberately omits it.
+    it 'names the package as name@version in the skip warning' do
+      expect { parser.parse('package-lock.json', packages) }
+        .to(output(/Skipping lodash@4\.17\.21: network timeout after retries/).to_stderr)
+    end
   end
 
   context 'when license is Unlicense' do

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe(SOUP::YarnParser) do
       expect(packages).to(be_empty)
       expect(a_request(:get, url)).to(have_been_made.times(SOUP::HttpClient.max_retries + 1))
     end
+
+    # QUAL-001: the warning now comes from the shared
+    # BaseParser#npm_registry_response, named from the `label` this parser
+    # passes. A timeout is skipped here even though a non-200 raises.
+    it 'names the package as name@version in the skip warning' do
+      expect { parser.parse('yarn.lock', packages) }
+        .to(output(/Skipping lodash@4\.17\.21: network timeout after retries/).to_stderr)
+    end
   end
 
   context 'when the resolved version is not in the registry' do


### PR DESCRIPTION
## Summary

The registry.npmjs.org fetch flow was triplicated across the NPM, Yarn, and Importmap parsers, so a fix to one could silently miss the other two — as already happened with the licence coercion in QUAL-002. This extracts the shared parts into `BaseParser`, alongside the existing `lookup_npm_registry_version` / `npm_registry_license` helpers established by PR #335.

**Key changes:**

- `lib/soup/parsers/base.rb`: added the `NPM_REGISTRY_ROOT` private constant and three helpers — `npm_registry_url(name)`, `npm_registry_response(name:, label: name)` (GET plus the post-retry timeout rescue, returning `nil` after warning), and `build_npm_registry_package(...)` (the shared `build_package` tail)
- `lib/soup/parsers/npm.rb`, `lib/soup/parsers/yarn.rb`, `lib/soup/parsers/importmap.rb`: now call the helpers; Importmap's now-redundant local `REGISTRY_ROOT` constant is removed
- `spec/soup/importmap_parser_spec.rb`: added the missing registry-timeout spec
- `spec/soup/npm_parser_spec.rb`, `spec/soup/yarn_parser_spec.rb`: added assertions on the skip-warning text

### Design note for reviewers: the three copies were not interchangeable

Yarn `raise`s `RegistryError` on a non-200, which aborts the entire scan through `bin/soup.rb`'s top-level rescue. NPM and Importmap warn and skip the package. Unifying that split is **CONS-001**, explicitly out of scope here, so `npm_registry_response` deliberately stops short of the non-200 branch and every parser keeps its own policy verbatim. A comment at Yarn's `raise` now points at CONS-001 so the divergence reads as deliberate rather than as an oversight.

The `label:` default preserves the per-parser warning text. NPM and Yarn know the version up front and pass `"name@version"`; Importmap cannot, because it resolves the version from the very response it is still awaiting, so it names the package alone.

### Behaviour preservation

Proven by **pre-existing** specs that pass unchanged:

- `yarn_parser_spec.rb:81` asserts `RegistryError` matching `/HTTP 500.*lodash.*registry\.npmjs\.org/m`, which also confirms `npm_registry_url` yields a byte-identical URL
- `npm_parser_spec.rb:66` and `importmap_parser_spec.rb:80` assert 404 → skip

### A gap the extraction surfaced

Branch coverage initially *dropped* (88.84% → 88.72%). Traced to `importmap.rb:56` `return if response.nil?`: the Importmap timeout path had never been tested, while NPM and Yarn both had timeout specs. Moving the rescue into a shared helper turned a silently-untested line into a visibly-untested branch, so the missing spec was added.

The two message assertions matter for the same reason: nothing previously asserted the `Skipping ...` text (only HttpClient's "Aborting after N retries"), which left the `label:` mechanism entirely unverified. Confirmed load-bearing by making Importmap pass a label — the test then failed with `Skipping marked@12.0.0:` instead of `Skipping marked:`.

Verification: full suite 265 examples, 0 failures; RuboCop clean across all 39 files; line coverage 98.47% -> 98.76%, branch coverage 88.84% -> 89.09%.

Closes #385

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
