### PR TITLE
#384: migrate remaining File stubs to write_fixture tmpdir fixtures

### DIFF
--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -102,12 +102,15 @@ RSpec.describe(SOUP::Application) do
     ] + skip_all_parsers
   end
 
+  # TEST-12: the lockfile and its sibling composer.json are written to a
+  # per-example tmpdir and Dir.glob is pointed at the real path, so the parser
+  # reads actual bytes. Dir stubbing stays -- detect_packages globs Dir.pwd, and
+  # Dir is not File stubbing.
   def stub_composer_files(lock_content, json_content)
+    write_fixture('composer.json', json_content)
+    lockfile_path = write_fixture('composer.lock', lock_content)
     allow(Dir).to(receive(:glob).and_return([]))
-    allow(Dir).to(receive(:glob).with("#{Dir.pwd}/**/composer.lock").and_return(['composer.lock']))
-    allow(File).to(receive(:read).and_call_original)
-    allow(File).to(receive(:read).with('composer.lock').and_return(lock_content))
-    allow(File).to(receive(:read).with('composer.json').and_return(json_content))
+    allow(Dir).to(receive(:glob).with("#{Dir.pwd}/**/composer.lock").and_return([lockfile_path]))
   end
 
   def default_composer_lock

--- a/spec/soup/base_parser_spec.rb
+++ b/spec/soup/base_parser_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe(SOUP::BaseParser) do
                :build_package,
                :normalize_license,
                :npm_registry_license,
+               :sibling_file,
                :http_error_message
       end
     end
@@ -95,6 +96,25 @@ RSpec.describe(SOUP::BaseParser) do
 
       it 'returns an empty string for nil so normalize_license stays Hash-free' do
         expect(parser.npm_registry_license(nil)).to(eq(''))
+      end
+    end
+
+    # CONS-007: before the TEST-12 fixture migration, the bare-basename branch
+    # was covered only incidentally, by parser specs that stubbed File.read and
+    # so passed 'composer.lock' rather than a real path. Now that every fixture
+    # is a real absolute tmpdir path, the helper is asserted directly instead.
+    describe '#sibling_file' do
+      it 'returns the bare suffix when the file has no directory component' do
+        expect(parser.sibling_file('composer.lock', 'composer.json')).to(eq('composer.json'))
+      end
+
+      it 'joins the suffix onto the file\'s directory for a nested path' do
+        expect(parser.sibling_file('/tmp/proj/composer.lock', 'composer.json')).to(eq('/tmp/proj/composer.json'))
+      end
+
+      it 'does not corrupt a directory whose name contains the lockfile name' do
+        expect(parser.sibling_file('/Users/sherlock/composer.lock', 'composer.json'))
+          .to(eq('/Users/sherlock/composer.json'))
       end
     end
 

--- a/spec/soup/composer_parser_spec.rb
+++ b/spec/soup/composer_parser_spec.rb
@@ -30,11 +30,16 @@ RSpec.describe(SOUP::ComposerParser) do
 
   let(:packages) { {} }
 
+  # TEST-12: lockfile and its sibling composer.json are written to a per-example
+  # tmpdir, so the parser resolves composer.json through the real sibling_file
+  # path handling rather than File.read stubs keyed to bare basenames.
+  def lockfile_path
+    write_fixture('composer.json', main_file)
+    write_fixture('composer.lock', lock_file)
+  end
+
   before do |example|
-    allow(File).to(receive(:read).and_call_original)
-    allow(File).to(receive(:read).with('composer.lock').and_return(lock_file))
-    allow(File).to(receive(:read).with('composer.json').and_return(main_file))
-    parser.parse('composer.lock', packages) if example.metadata.fetch(:auto_parse, true)
+    parser.parse(lockfile_path, packages) if example.metadata.fetch(:auto_parse, true)
   end
 
   it 'parses packages and packages-dev', :aggregate_failures do
@@ -179,8 +184,7 @@ RSpec.describe(SOUP::ComposerParser) do
     # Regression test for BUG-04: pre-fix the parser used file.gsub('lock',
     # 'json'), an unanchored substring substitution that corrupted any path
     # containing "lock" (e.g. /Users/sherlock/proj/composer.lock).
-    let(:lock_file_path) { '/Users/sherlock/proj/composer.lock' }
-    let(:main_file_path) { '/Users/sherlock/proj/composer.json' }
+    let(:main_file) { '{"require":{"vendor/x":"^1.0"}}' }
     let(:lock_file) do
       {
         packages: [
@@ -190,10 +194,11 @@ RSpec.describe(SOUP::ComposerParser) do
       }.to_json
     end
 
-    before do
-      allow(File).to(receive(:read).with(lock_file_path).and_return(lock_file))
-      allow(File).to(receive(:read).with(main_file_path).and_return('{"require":{"vendor/x":"^1.0"}}'))
-      parser.parse(lock_file_path, packages)
+    # A real directory named "sherlock" on disk, so the path actually contains
+    # the "lock" substring the old gsub corrupted.
+    let(:lockfile_path) do
+      write_fixture('sherlock/proj/composer.json', main_file)
+      write_fixture('sherlock/proj/composer.lock', lock_file)
     end
 
     it 'reads composer.json from the same directory without corrupting the path' do
@@ -271,12 +276,12 @@ RSpec.describe(SOUP::ComposerParser) do
   # backtrace. Locking in current behavior so a future improvement (clearer
   # message) is deliberate.
   context 'when the lockfile itself is missing at read time', auto_parse: false do
-    before do
-      allow(File).to(receive(:read).with('composer.lock').and_raise(Errno::ENOENT.new('composer.lock')))
-    end
+    # Points at a path inside the fixture dir that was never written, so the
+    # real File.read raises ENOENT instead of a stub simulating it.
+    let(:lockfile_path) { File.join(fixture_dir, 'gone', 'composer.lock') }
 
     it 'surfaces Errno::ENOENT' do
-      expect { parser.parse('composer.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(Errno::ENOENT))
     end
   end
@@ -288,7 +293,7 @@ RSpec.describe(SOUP::ComposerParser) do
     let(:lock_file) { 'not json' }
 
     it 'raises JSON::ParserError on non-JSON garbage' do
-      expect { parser.parse('composer.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(JSON::ParserError))
     end
 
@@ -296,7 +301,7 @@ RSpec.describe(SOUP::ComposerParser) do
       let(:lock_file) { '' }
 
       it 'raises JSON::ParserError' do
-        expect { parser.parse('composer.lock', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(raise_error(JSON::ParserError))
       end
     end
@@ -305,18 +310,15 @@ RSpec.describe(SOUP::ComposerParser) do
       let(:lock_file) { '{"packages":[{"name":"vendor/x"' }
 
       it 'raises JSON::ParserError' do
-        expect { parser.parse('composer.lock', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(raise_error(JSON::ParserError))
       end
     end
   end
 
-  # TEST-12 follow-up: parser exercised against real lockfile bytes via
-  # SoupFixtureHelpers. Uses auto_parse: false so the outer before-hook does
-  # not invoke parser.parse with the stubbed 'composer.lock' literal before
-  # the example writes its real fixture path.
-  context 'with real fixture files on disk', auto_parse: false do
-    let(:tmpdir_lock_content) do
+  # TEST-12: a minimal single-package lockfile read straight off disk.
+  context 'with a single-package lockfile on disk' do
+    let(:lock_file) do
       {
         packages: [
           {
@@ -332,9 +334,6 @@ RSpec.describe(SOUP::ComposerParser) do
     end
 
     it 'reads the lockfile + composer.json from disk without File stubs' do
-      write_fixture('composer.json', '{"require":{"vendor/main-pkg":"^1.0"}}')
-      lockfile_path = write_fixture('composer.lock', tmpdir_lock_content)
-      parser.parse(lockfile_path, packages)
       expect(packages['vendor/main-pkg']).to(have_attributes(language: 'PHP', version: '1.0.0', license: 'MIT'))
     end
   end

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -28,12 +28,19 @@ RSpec.describe(SOUP::GradleParser) do
     }.to_json
   end
 
-  before do
-    allow(File).to(receive(:readlines).and_call_original)
-    allow(File).to(receive(:readlines).with('buildscript-gradle.lockfile').and_return(lock_content))
-    allow(File).to(receive(:read).and_call_original)
-    allow(File).to(receive(:read).with('build.gradle').and_return(main_file))
+  def lockfile_path
+    write_fixture(main_file_name, main_file) unless main_file.nil?
+    write_fixture(lockfile_name, Array(lock_content).join)
   end
+
+  # TEST-12: the lockfile and its sibling build script are written to a
+  # per-example tmpdir. Which manifest exists is expressed by writing it or not
+  # -- `main_file_name` selects the Groovy or Kotlin DSL, and a nil `main_file`
+  # writes neither -- so the parser's real Errno::ENOENT fallback runs instead
+  # of a stubbed one.
+  def lockfile_name = 'buildscript-gradle.lockfile'
+
+  def main_file_name = 'build.gradle'
 
   context 'when Maven Central search succeeds' do
     let(:packages) { {} }
@@ -42,7 +49,7 @@ RSpec.describe(SOUP::GradleParser) do
       stub_request(:get, %r{search\.maven\.org/solrsearch/select})
         .to_return(status: 200, body: maven_response)
 
-      parser.parse('buildscript-gradle.lockfile', packages)
+      parser.parse(lockfile_path, packages)
     end
 
     it 'parses lockfile and only processes classpath entries', :aggregate_failures do
@@ -92,7 +99,7 @@ RSpec.describe(SOUP::GradleParser) do
 
     it 'falls back to POM XML instead of crashing' do
       packages = {}
-      parser.parse('buildscript-gradle.lockfile', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['com.example:library'].license).to(eq('MIT License'))
     end
   end
@@ -130,7 +137,7 @@ RSpec.describe(SOUP::GradleParser) do
 
       it 'falls back to POM XML from repository URLs', :aggregate_failures do
         packages = {}
-        parser.parse('buildscript-gradle.lockfile', packages)
+        parser.parse(lockfile_path, packages)
         pkg = packages['com.example:library']
         expect(pkg.license).to(eq('MIT License'))
         expect(pkg.description).to(eq('Fallback description'))
@@ -152,7 +159,7 @@ RSpec.describe(SOUP::GradleParser) do
 
       it 'tries multiple repository URLs until one succeeds' do
         packages = {}
-        parser.parse('buildscript-gradle.lockfile', packages)
+        parser.parse(lockfile_path, packages)
         expect(packages).to(have_key('com.example:library'))
       end
     end
@@ -171,7 +178,7 @@ RSpec.describe(SOUP::GradleParser) do
 
       it 'warns with http_error_message (status, url, package, truncated body)', :aggregate_failures do
         packages = {}
-        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(output(/HTTP 503.*com\.example:library 1\.0\.0.*\.pom.*offline/m).to_stderr)
         expect(packages).to(be_empty)
       end
@@ -207,7 +214,7 @@ RSpec.describe(SOUP::GradleParser) do
 
       it 'falls through to the POM mirror instead of aborting', :aggregate_failures do
         packages = {}
-        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .not_to(raise_error)
         expect(packages['com.example:library'].license).to(eq('MIT License'))
       end
@@ -224,7 +231,7 @@ RSpec.describe(SOUP::GradleParser) do
 
       it 'warns and skips the package without raising', :aggregate_failures do
         packages = {}
-        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(output(/all Maven lookups timed out/).to_stderr)
         expect(packages).to(be_empty)
       end
@@ -232,16 +239,16 @@ RSpec.describe(SOUP::GradleParser) do
   end
 
   context 'when package is not in main file' do
+    let(:main_file) { 'no match here' }
+
     before do
       stub_request(:get, %r{search\.maven\.org/solrsearch/select})
         .to_return(status: 200, body: maven_response)
-
-      allow(File).to(receive(:read).with('build.gradle').and_return('no match here'))
     end
 
     it 'marks dependency based on main file content' do
       packages = {}
-      parser.parse('buildscript-gradle.lockfile', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['com.example:library'].dependency).to(be(true))
     end
   end
@@ -261,43 +268,46 @@ RSpec.describe(SOUP::GradleParser) do
 
     it 'classifies the substring coordinate as transitive' do
       packages = {}
-      parser.parse('buildscript-gradle.lockfile', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['com.example:lib'].dependency).to(be(true))
     end
   end
 
   context 'when only build.gradle.kts (Kotlin DSL) exists' do
-    before do
-      allow(File).to(receive(:read).with('build.gradle').and_raise(Errno::ENOENT))
-      allow(File).to(receive(:read).with('build.gradle.kts').and_return(main_file))
+    # Only the Kotlin DSL file is written, so the parser's real ENOENT rescue
+    # on build.gradle drives the fallback.
+    let(:main_file_name) { 'build.gradle.kts' }
 
+    before do
       stub_request(:get, %r{search\.maven\.org/solrsearch/select})
         .to_return(status: 200, body: maven_response)
     end
 
     it 'falls back to build.gradle.kts instead of crashing', :aggregate_failures do
       packages = {}
-      expect { parser.parse('buildscript-gradle.lockfile', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
       expect(packages).to(have_key('com.example:library'))
     end
   end
 
   context 'when neither build.gradle nor build.gradle.kts exists' do
-    before do
-      allow(File).to(receive(:read).with('build.gradle').and_raise(Errno::ENOENT))
-      allow(File).to(receive(:read).with('build.gradle.kts').and_raise(Errno::ENOENT))
-    end
+    # No manifest of either name is written to the fixture dir.
+    let(:main_file) { nil }
 
     it 'raises a clear error rather than a bare ENOENT' do
       packages = {}
-      expect { parser.parse('buildscript-gradle.lockfile', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(SOUP::InvalidLockfileError, /No build\.gradle or build\.gradle\.kts found/))
     end
   end
 
   context 'when parsing an application gradle.lockfile (runtime classpath)' do
-    let(:runtime_lock_content) do
+    def lockfile_name = 'app/gradle.lockfile'
+
+    def main_file_name = 'app/build.gradle'
+
+    let(:lock_content) do
       [
         "# Gradle dependency lock file\n",
         "androidx.activity:activity-compose:1.10.1=googleProdDebugRuntimeClasspath,googleProdReleaseRuntimeClasspath\n",
@@ -309,10 +319,9 @@ RSpec.describe(SOUP::GradleParser) do
       ]
     end
 
-    before do
-      allow(File).to(receive(:readlines).with('app/gradle.lockfile').and_return(runtime_lock_content))
-      allow(File).to(receive(:read).with('app/build.gradle').and_return('implementation "androidx.activity:activity-compose:1.10.1"'))
+    let(:main_file) { 'implementation "androidx.activity:activity-compose:1.10.1"' }
 
+    before do
       stub_request(:get, %r{search\.maven\.org/solrsearch/select})
         .to_return(status: 200, body: maven_response)
     end
@@ -320,20 +329,20 @@ RSpec.describe(SOUP::GradleParser) do
     it 'derives the build.gradle path from the lockfile location' do
       packages = {}
       expect do
-        parser.parse('app/gradle.lockfile', packages)
+        parser.parse(lockfile_path, packages)
       end.not_to(raise_error)
     end
 
     it 'includes production runtime classpath entries', :aggregate_failures do
       packages = {}
-      parser.parse('app/gradle.lockfile', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(have_key('androidx.activity:activity-compose'))
       expect(packages).to(have_key('com.example:runtime-lib'))
     end
 
     it 'excludes test, debug-only, and compile-only configurations', :aggregate_failures do
       packages = {}
-      parser.parse('app/gradle.lockfile', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).not_to(have_key('androidx.test:runner'))
       expect(packages).not_to(have_key('com.example:debug-only'))
       expect(packages).not_to(have_key('com.example:compile-only'))
@@ -341,7 +350,7 @@ RSpec.describe(SOUP::GradleParser) do
 
     it 'flags transitive dependencies not declared in build.gradle', :aggregate_failures do
       packages = {}
-      parser.parse('app/gradle.lockfile', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['com.example:runtime-lib'].dependency).to(be(true))
       expect(packages['androidx.activity:activity-compose'].dependency).to(be(false))
     end
@@ -353,47 +362,33 @@ RSpec.describe(SOUP::GradleParser) do
   describe '#parse with malformed input' do
     let(:packages) { {} }
 
-    before do
-      allow(File).to(receive(:read).and_call_original)
-      allow(File).to(receive(:read).with('build.gradle').and_return("dependencies {}\n"))
-      allow(File).to(receive(:read).with('build.gradle.kts').and_raise(Errno::ENOENT))
-    end
+    let(:main_file) { "dependencies {}\n" }
 
     context 'with an empty gradle.lockfile' do
-      before do
-        allow(File).to(receive(:readlines).with('buildscript-gradle.lockfile').and_return([]))
-      end
+      let(:lock_content) { [] }
 
       it 'parses without raising and adds no packages', :aggregate_failures do
-        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .not_to(raise_error)
         expect(packages).to(be_empty)
       end
     end
 
     context 'with a comment-only gradle.lockfile' do
-      let(:lines) { ["# This is a Gradle generated file\n", "# Do not edit\n"] }
-
-      before do
-        allow(File).to(receive(:readlines).with('buildscript-gradle.lockfile').and_return(lines))
-      end
+      let(:lock_content) { ["# This is a Gradle generated file\n", "# Do not edit\n"] }
 
       it 'parses without raising and adds no packages', :aggregate_failures do
-        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .not_to(raise_error)
         expect(packages).to(be_empty)
       end
     end
 
     context 'with malformed lines missing the = separator' do
-      let(:lines) { ["garbage line without equals\n", "another garbage line\n"] }
-
-      before do
-        allow(File).to(receive(:readlines).with('buildscript-gradle.lockfile').and_return(lines))
-      end
+      let(:lock_content) { ["garbage line without equals\n", "another garbage line\n"] }
 
       it 'parses without raising and adds no packages (silently skipped)', :aggregate_failures do
-        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .not_to(raise_error)
         expect(packages).to(be_empty)
       end
@@ -402,40 +397,33 @@ RSpec.describe(SOUP::GradleParser) do
     # TEST-05: race where Dir.glob found the lockfile but it was deleted /
     # unreadable before File.readlines ran.
     context 'when the lockfile cannot be read' do
-      before do
-        allow(File).to(
-          receive(:readlines)
-                    .with('buildscript-gradle.lockfile').and_raise(Errno::ENOENT.new('buildscript-gradle.lockfile'))
-        )
-      end
+      # A path inside the fixture dir that was never written, so the real
+      # File.readlines raises ENOENT instead of a stub simulating it.
+      let(:lockfile_path) { File.join(fixture_dir, 'gone', 'buildscript-gradle.lockfile') }
 
       it 'surfaces Errno::ENOENT' do
-        expect { parser.parse('buildscript-gradle.lockfile', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(raise_error(Errno::ENOENT))
       end
     end
 
-    # TEST-12 follow-up: parser exercised against real Gradle fixtures via
-    # SoupFixtureHelpers. File.readlines / File.read stubs bypassed with
-    # and_call_original so real filesystem reads run.
-    context 'with real Gradle fixtures on disk' do
-      let(:tmpdir_lockfile_bytes) do
+    # TEST-12: a well-formed lockfile plus sibling build.gradle read off disk.
+    context 'with a well-formed lockfile on disk' do
+      let(:lock_content) do
         <<~LOCK
           # This is a Gradle lockfile
           com.example:library:1.0.0=classpath
         LOCK
       end
 
+      let(:main_file) { 'classpath "com.example:library:1.0.0"' }
+
       before do
-        allow(File).to(receive(:readlines).and_call_original)
-        allow(File).to(receive(:read).and_call_original)
         stub_request(:get, %r{search\.maven\.org/solrsearch/select})
           .to_return(status: 200, body: maven_response)
       end
 
       it 'reads the lockfile + sibling build.gradle from disk without File stubs' do
-        write_fixture('build.gradle', 'classpath "com.example:library:1.0.0"')
-        lockfile_path = write_fixture('buildscript-gradle.lockfile', tmpdir_lockfile_bytes)
         packages = {}
         parser.parse(lockfile_path, packages)
         expect(packages['com.example:library']).to(have_attributes(language: 'Kotlin', version: '1.0.0', license: 'Apache-2.0'))
@@ -478,7 +466,7 @@ RSpec.describe(SOUP::GradleParser) do
 
     it 'parses all 100 classpath entries without raising and adds them to the hash', :aggregate_failures do
       packages = {}
-      parser.parse('buildscript-gradle.lockfile', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages.size).to(eq(100))
       expect(packages['com.example:lib-1']).to(have_attributes(language: 'Kotlin', version: '1.0.0', license: 'Apache-2.0'))
       expect(packages['com.example:lib-100']).to(have_attributes(language: 'Kotlin', version: '1.0.0', license: 'Apache-2.0'))

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe(SOUP::NPMParser) do
     }.to_json
   end
 
-  before do
-    allow(File).to(receive(:read).and_call_original)
-    allow(File).to(receive(:read).with('package-lock.json').and_return(lock_file))
-    allow(File).to(receive(:read).with('package.json').and_return(main_file))
+  # TEST-12: lockfile and its sibling package.json are written to a per-example
+  # tmpdir, so the parser resolves package.json through the real sibling_file
+  # path handling rather than a File.read stub keyed to a bare basename.
+  def lockfile_path
+    write_fixture('package.json', main_file)
+    write_fixture('package-lock.json', lock_file)
   end
 
   context 'with successful registry response' do
@@ -41,7 +43,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     let(:packages) do
       result = {}
-      parser.parse('package-lock.json', result)
+      parser.parse(lockfile_path, result)
       result
     end
 
@@ -68,7 +70,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     it 'skips on non-200 response' do
       packages = {}
-      parser.parse('package-lock.json', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(be_empty)
     end
   end
@@ -83,12 +85,12 @@ RSpec.describe(SOUP::NPMParser) do
     before { stub_request(:get, url).to_timeout }
 
     it 'emits the "Aborting after N retries" stderr warning' do
-      expect { parser.parse('package-lock.json', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(output(/Aborting after \d+ retries/).to_stderr)
     end
 
     it 'retries max_retries+1 times before skipping the package', :aggregate_failures do
-      parser.parse('package-lock.json', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(be_empty)
       expect(a_request(:get, url)).to(have_been_made.times(SOUP::HttpClient.max_retries + 1))
     end
@@ -98,7 +100,7 @@ RSpec.describe(SOUP::NPMParser) do
     # this parser passes. NPM knows the version up front, so it must stay
     # "name@version" -- Importmap, which cannot, deliberately omits it.
     it 'names the package as name@version in the skip warning' do
-      expect { parser.parse('package-lock.json', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(output(/Skipping lodash@4\.17\.21: network timeout after retries/).to_stderr)
     end
   end
@@ -123,7 +125,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     it 'converts Unlicense to NOASSERTION' do
       packages = {}
-      parser.parse('package-lock.json', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['lodash'].license).to(eq('NOASSERTION'))
     end
   end
@@ -136,7 +138,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     it 'handles version not found in registry' do
       packages = {}
-      parser.parse('package-lock.json', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(be_empty)
     end
   end
@@ -149,7 +151,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     it 'handles unpublished or stub-only packages without raising', :aggregate_failures do
       packages = {}
-      expect { parser.parse('package-lock.json', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
       expect(packages).to(be_empty)
     end
@@ -165,7 +167,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     it 'classifies overrides-only packages as transitive (not direct)' do
       packages = {}
-      parser.parse('package-lock.json', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['lodash'].dependency).to(be(false))
     end
   end
@@ -193,7 +195,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     it 'is treated as transitive even though it appears in overrides' do
       packages = {}
-      parser.parse('package-lock.json', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['transitive-only'].dependency).to(be(true))
     end
   end
@@ -207,7 +209,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     it 'raises a clear unsupported-format error', :aggregate_failures do
       packages = {}
-      expect { parser.parse('package-lock.json', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(SOUP::UnsupportedFormatError, /Unsupported package-lock\.json/))
       expect(packages).to(be_empty)
     end
@@ -240,7 +242,7 @@ RSpec.describe(SOUP::NPMParser) do
 
     it 'parses all 100 packages without raising and adds them to the hash', :aggregate_failures do
       packages = {}
-      parser.parse('package-lock.json', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages.size).to(eq(100))
       expect(packages['pkg-1']).to(have_attributes(license: 'MIT', version: '1.0.0'))
       expect(packages['pkg-100']).to(have_attributes(license: 'MIT', version: '1.0.0'))
@@ -250,21 +252,21 @@ RSpec.describe(SOUP::NPMParser) do
   # TEST-05: race where Dir.glob found the lockfile but it was deleted /
   # unreadable before File.read ran.
   context 'when package-lock.json cannot be read' do
-    before do
-      allow(File).to(receive(:read).with('package-lock.json').and_raise(Errno::ENOENT.new('package-lock.json')))
-    end
+    # Points at a path inside the fixture dir that was never written, so the
+    # real File.read raises ENOENT instead of a stub simulating it.
+    let(:lockfile_path) { File.join(fixture_dir, 'gone', 'package-lock.json') }
 
     it 'surfaces Errno::ENOENT' do
       packages = {}
-      expect { parser.parse('package-lock.json', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(Errno::ENOENT))
     end
   end
 
   # TEST-12 follow-up: parser exercised against real lockfile bytes via
   # SoupFixtureHelpers, demonstrating the no-stub pattern for npm.
-  context 'with a real package-lock.json fixture on disk' do
-    let(:lockfile_bytes) do
+  context 'with a real lockfileVersion 3 package-lock.json on disk' do
+    let(:lock_file) do
       {
         lockfileVersion: 3,
         packages: {
@@ -280,8 +282,6 @@ RSpec.describe(SOUP::NPMParser) do
     end
 
     it 'reads both files from disk without File stubs' do
-      write_fixture('package.json', main_file)
-      lockfile_path = write_fixture('package-lock.json', lockfile_bytes)
       packages = {}
       parser.parse(lockfile_path, packages)
       expect(packages['lodash']).to(have_attributes(language: 'JS', version: '4.17.21', license: 'MIT'))

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -46,14 +46,16 @@ RSpec.describe(SOUP::PIPParser) do
     }.to_json
   end
 
-  before do
-    allow(File).to(receive(:exist?).and_call_original)
-    allow(File).to(receive(:exist?).with('requirements.in').and_return(false))
-    allow(File).to(receive(:foreach).and_call_original)
-    foreach_stub = receive(:foreach).with('requirements.txt')
-    requirements_content.lines.each { |line| foreach_stub.and_yield(line) }
-    allow(File).to(foreach_stub)
+  def requirements_path
+    write_fixture('requirements.in', requirements_in_content) unless requirements_in_content.nil?
+    write_fixture('requirements.txt', requirements_content)
   end
+
+  # TEST-12: requirements.txt (and the sibling requirements.in, when the case
+  # needs one) are written to a per-example tmpdir. Whether the .in file exists
+  # is expressed by writing it or not, so the parser's real File.exist? check
+  # runs instead of a stubbed one.
+  def requirements_in_content = nil
 
   context 'when parsing all three packages' do
     before do
@@ -67,7 +69,7 @@ RSpec.describe(SOUP::PIPParser) do
 
     let(:packages) do
       result = {}
-      parser.parse('requirements.txt', result)
+      parser.parse(requirements_path, result)
       result
     end
 
@@ -101,15 +103,10 @@ RSpec.describe(SOUP::PIPParser) do
   end
 
   context 'when .in file exists for dependency detection' do
+    let(:requirements_in_content) { "requests\n"                       }
+    let(:requirements_content)    { "requests==2.31.0\nflask==3.0.0\n" }
+
     before do
-      allow(File).to(receive(:exist?).with('requirements.in').and_return(true))
-      allow(File).to(receive(:read).and_call_original)
-      allow(File).to(receive(:read).with('requirements.in').and_return("requests\n"))
-
-      foreach_stub = receive(:foreach).with('requirements.txt')
-      "requests==2.31.0\nflask==3.0.0\n".lines.each { |line| foreach_stub.and_yield(line) }
-      allow(File).to(foreach_stub)
-
       stub_request(:get, 'https://pypi.org/pypi/requests/json')
         .to_return(status: 200, body: requests_response)
       stub_request(:get, 'https://pypi.org/pypi/flask/json')
@@ -118,7 +115,7 @@ RSpec.describe(SOUP::PIPParser) do
 
     it 'uses .in file for dependency detection if it exists', :aggregate_failures do
       packages = {}
-      parser.parse('requirements.txt', packages)
+      parser.parse(requirements_path, packages)
       expect(packages['requests'].dependency).to(be(false))
       expect(packages['flask'].dependency).to(be(true))
     end
@@ -128,22 +125,17 @@ RSpec.describe(SOUP::PIPParser) do
   # declared requirement (requests within requests-oauthlib) must NOT be flagged
   # direct. The old String#include? scan of requirements.in mis-classified it.
   context 'when a transitive package name is a substring of a declared requirement' do
+    let(:requirements_in_content) { "requests-oauthlib\n" }
+    let(:requirements_content) { "requests==2.31.0\n" }
+
     before do
-      allow(File).to(receive(:exist?).with('requirements.in').and_return(true))
-      allow(File).to(receive(:read).and_call_original)
-      allow(File).to(receive(:read).with('requirements.in').and_return("requests-oauthlib\n"))
-
-      foreach_stub = receive(:foreach).with('requirements.txt')
-      "requests==2.31.0\n".lines.each { |line| foreach_stub.and_yield(line) }
-      allow(File).to(foreach_stub)
-
       stub_request(:get, 'https://pypi.org/pypi/requests/json')
         .to_return(status: 200, body: requests_response)
     end
 
     it 'classifies the substring package as transitive' do
       packages = {}
-      parser.parse('requirements.txt', packages)
+      parser.parse(requirements_path, packages)
       expect(packages['requests'].dependency).to(be(true))
     end
   end
@@ -151,27 +143,24 @@ RSpec.describe(SOUP::PIPParser) do
   # The .in / lockfile names are compared with PEP 503 normalization, so a
   # declared "Flask_Login" still matches the resolved "flask-login".
   context 'when the declared name differs only by case and separators' do
+    let(:requirements_in_content) { "Flask_Login\n" }
+    let(:requirements_content) { "flask-login==0.6.3\n" }
+
     before do
-      allow(File).to(receive(:exist?).with('requirements.in').and_return(true))
-      allow(File).to(receive(:read).and_call_original)
-      allow(File).to(receive(:read).with('requirements.in').and_return("Flask_Login\n"))
-
-      foreach_stub = receive(:foreach).with('requirements.txt')
-      "flask-login==0.6.3\n".lines.each { |line| foreach_stub.and_yield(line) }
-      allow(File).to(foreach_stub)
-
       stub_request(:get, 'https://pypi.org/pypi/flask-login/json')
         .to_return(status: 200, body: flask_response)
     end
 
     it 'classifies the normalized match as a direct dependency' do
       packages = {}
-      parser.parse('requirements.txt', packages)
+      parser.parse(requirements_path, packages)
       expect(packages['flask-login'].dependency).to(be(false))
     end
   end
 
   context 'when home_page is nil' do
+    let(:requirements_content) { "simple==1.0.0\n" }
+
     let(:nil_homepage_response) do
       {
         info: {
@@ -184,14 +173,13 @@ RSpec.describe(SOUP::PIPParser) do
     end
 
     before do
-      allow(File).to(receive(:foreach).with('requirements.txt').and_yield("simple==1.0.0\n"))
       stub_request(:get, 'https://pypi.org/pypi/simple/json')
         .to_return(status: 200, body: nil_homepage_response)
     end
 
     it 'handles nil home_page' do
       packages = {}
-      parser.parse('requirements.txt', packages)
+      parser.parse(requirements_path, packages)
       expect(packages['simple'].website).to(be_nil)
     end
   end
@@ -202,8 +190,9 @@ RSpec.describe(SOUP::PIPParser) do
   # expectation fails on a revert instead of merely erroring on an unregistered
   # request.
   context 'when resolving the PyPI registry host' do
+    let(:requirements_content) { "requests==2.31.0\n" }
+
     before do
-      allow(File).to(receive(:foreach).with('requirements.txt').and_yield("requests==2.31.0\n"))
       stub_request(:get, 'https://pypi.org/pypi/requests/json')
         .to_return(status: 200, body: requests_response)
       stub_request(:get, 'https://pypi.python.org/pypi/requests/json')
@@ -212,25 +201,18 @@ RSpec.describe(SOUP::PIPParser) do
 
     it 'queries pypi.org and never the retired pypi.python.org domain', :aggregate_failures do
       packages = {}
-      parser.parse('requirements.txt', packages)
+      parser.parse(requirements_path, packages)
       expect(a_request(:get, 'https://pypi.org/pypi/requests/json')).to(have_been_made)
       expect(a_request(:get, 'https://pypi.python.org/pypi/requests/json')).not_to(have_been_made)
     end
   end
 
   context 'when a requirement uses a non-`==` constraint' do
-    before do
-      allow(File).to(
-        receive(:foreach).with('requirements.txt')
-                         .and_yield("requests>=2.31.0\n")
-                         .and_yield("flask~=3.0.0\n")
-                         .and_yield("django!=4.0\n")
-      )
-    end
+    let(:requirements_content) { "requests>=2.31.0\nflask~=3.0.0\ndjango!=4.0\n" }
 
     it 'skips loose constraints with a stderr warning instead of issuing a doomed 404 request', :aggregate_failures do
       packages = {}
-      expect { parser.parse('requirements.txt', packages) }
+      expect { parser.parse(requirements_path, packages) }
         .to(output(/only exact `==` version pins are supported/).to_stderr)
       expect(WebMock).not_to(have_requested(:get, /pypi\.org/))
       expect(packages).to(be_empty)
@@ -242,13 +224,11 @@ RSpec.describe(SOUP::PIPParser) do
   # silently dropped. Before the fix, `next if line.include?('#')` skipped the
   # whole line; full-line comments must still be skipped via the blank guard.
   context 'when a requirement line has a trailing inline comment' do
+    let(:requirements_content) do
+      "# full-line comment\nrequests==2.31.0  # security pin\nflask==3.0.0  # pinned for CVE\n"
+    end
+
     before do
-      allow(File).to(
-        receive(:foreach).with('requirements.txt')
-                         .and_yield("# full-line comment\n")
-                         .and_yield("requests==2.31.0  # security pin\n")
-                         .and_yield("flask==3.0.0  # pinned for CVE\n")
-      )
       stub_request(:get, 'https://pypi.org/pypi/requests/json')
         .to_return(status: 200, body: requests_response)
       stub_request(:get, 'https://pypi.org/pypi/flask/json')
@@ -257,7 +237,7 @@ RSpec.describe(SOUP::PIPParser) do
 
     it 'strips the inline comment and parses the package', :aggregate_failures do
       packages = {}
-      parser.parse('requirements.txt', packages)
+      parser.parse(requirements_path, packages)
       expect(packages['requests'].version).to(eq('2.31.0'))
       expect(packages['flask'].version).to(eq('3.0.0'))
       expect(packages.size).to(eq(2))
@@ -265,6 +245,8 @@ RSpec.describe(SOUP::PIPParser) do
   end
 
   context 'when license is empty and no classifiers exist' do
+    let(:requirements_content) { "pkg==1.0.0\n" }
+
     let(:empty_license_response) do
       {
         info: {
@@ -277,14 +259,13 @@ RSpec.describe(SOUP::PIPParser) do
     end
 
     before do
-      allow(File).to(receive(:foreach).with('requirements.txt').and_yield("pkg==1.0.0\n"))
       stub_request(:get, 'https://pypi.org/pypi/pkg/json')
         .to_return(status: 200, body: empty_license_response)
     end
 
     it 'handles empty license and no classifiers' do
       packages = {}
-      parser.parse('requirements.txt', packages)
+      parser.parse(requirements_path, packages)
       expect(packages['pkg'].license).to(be_nil)
     end
   end
@@ -295,32 +276,21 @@ RSpec.describe(SOUP::PIPParser) do
   describe '#parse with malformed input' do
     let(:packages) { {} }
 
-    before do
-      allow(File).to(receive(:exist?).and_call_original)
-      allow(File).to(receive(:exist?).with('requirements.in').and_return(false))
-    end
-
     context 'with an empty requirements.txt' do
-      before do
-        allow(File).to(receive(:foreach).with('requirements.txt'))
-      end
+      let(:requirements_content) { '' }
 
       it 'parses without raising and adds no packages', :aggregate_failures do
-        expect { parser.parse('requirements.txt', packages) }
+        expect { parser.parse(requirements_path, packages) }
           .not_to(raise_error)
         expect(packages).to(be_empty)
       end
     end
 
     context 'with a comment-and-blank-line-only requirements.txt' do
-      before do
-        ["# header comment\n", "\n", "  \n", "# another comment\n"].each do |line|
-          allow(File).to(receive(:foreach).with('requirements.txt').and_yield(line))
-        end
-      end
+      let(:requirements_content) { "# header comment\n\n  \n# another comment\n" }
 
       it 'parses without raising and adds no packages', :aggregate_failures do
-        expect { parser.parse('requirements.txt', packages) }
+        expect { parser.parse(requirements_path, packages) }
           .not_to(raise_error)
         expect(packages).to(be_empty)
       end
@@ -329,27 +299,19 @@ RSpec.describe(SOUP::PIPParser) do
     # TEST-05: race where Dir.glob found the lockfile but it was deleted /
     # unreadable before File.foreach ran.
     context 'when requirements.txt cannot be read' do
-      before do
-        allow(File).to(
-          receive(:foreach)
-                    .with('requirements.txt').and_raise(Errno::ENOENT.new('requirements.txt'))
-        )
-      end
+      # A path inside the fixture dir that was never written, so the real
+      # File.foreach raises ENOENT instead of a stub simulating it.
+      def requirements_path = File.join(fixture_dir, 'gone', 'requirements.txt')
 
       it 'surfaces Errno::ENOENT' do
-        expect { parser.parse('requirements.txt', packages) }
+        expect { parser.parse(requirements_path, packages) }
           .to(raise_error(Errno::ENOENT))
       end
     end
 
-    # TEST-12 follow-up: parser exercised against a real requirements.txt
-    # via SoupFixtureHelpers. Stubs the .in / foreach defaults from the outer
-    # before are bypassed via and_call_original so real File.foreach reads
-    # the tmpdir fixture.
-    context 'with a real requirements.txt fixture on disk' do
+    # TEST-12: a requirements.txt mixing pins, comments and blank lines.
+    context 'with pins mixed among comments and blank lines' do
       before do
-        allow(File).to(receive(:exist?).and_call_original)
-        allow(File).to(receive(:foreach).and_call_original)
         body = {
           info: {
             summary: 'HTTP library',
@@ -362,9 +324,10 @@ RSpec.describe(SOUP::PIPParser) do
           .to_return(status: 200, body: body)
       end
 
+      let(:requirements_content) { "# top-level comment\nrequests==2.31.0\n\n" }
+
       it 'reads pinned requirements from disk and skips comments/blanks' do
-        lockfile_path = write_fixture('requirements.txt', "# top-level comment\nrequests==2.31.0\n\n")
-        parser.parse(lockfile_path, packages)
+        parser.parse(requirements_path, packages)
         expect(packages['requests']).to(have_attributes(language: 'Python', version: '2.31.0'))
       end
     end
@@ -395,7 +358,7 @@ RSpec.describe(SOUP::PIPParser) do
 
     it 'parses all 100 requirements without raising and adds them to the hash', :aggregate_failures do
       packages = {}
-      parser.parse('requirements.txt', packages)
+      parser.parse(requirements_path, packages)
       expect(packages.size).to(eq(100))
       expect(packages['pkg-1']).to(have_attributes(language: 'Python', version: '1.0.0'))
       expect(packages['pkg-100']).to(have_attributes(language: 'Python', version: '1.0.0'))

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -27,12 +27,22 @@ RSpec.describe(SOUP::SPMParser) do
     }.to_json
   end
 
+  def lockfile_path
+    write_fixture(manifest_name, main_file_content) unless manifest_name.nil?
+    write_fixture(resolved_name, resolved_file)
+  end
+
+  # TEST-12: Package.resolved and whichever Swift manifest the case needs are
+  # written to a per-example tmpdir. The manifest-discovery chain (Package.swift
+  # -> Tuist/Dependencies.swift -> *.xcodeproj/project.pbxproj -> enclosing
+  # pbxproj) is then driven by which files actually exist on disk, exercising the
+  # parser's real File.exist? walk instead of a stubbed one.
+  def manifest_name = 'Package.swift'
+
+  def resolved_name = 'Package.resolved'
+
+  # ENV stubbing is out of scope for the TEST-12 fixture migration.
   before do
-    allow(File).to(receive(:read).and_call_original)
-    allow(File).to(receive(:read).with('Package.resolved').and_return(resolved_file))
-    allow(File).to(receive(:exist?).and_call_original)
-    allow(File).to(receive(:exist?).with('Package.swift').and_return(true))
-    allow(File).to(receive(:read).with('Package.swift').and_return(main_file_content))
     allow(ENV).to(receive(:fetch).and_call_original)
     allow(ENV).to(receive(:fetch).with('GITHUB_TOKEN', '').and_return(''))
   end
@@ -45,7 +55,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     let(:packages) do
       result = {}
-      parser.parse('Package.resolved', result)
+      parser.parse(lockfile_path, result)
       result
     end
 
@@ -68,7 +78,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'sends GitHub token header when GITHUB_TOKEN is set' do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(have_key('Alamofire'))
     end
   end
@@ -87,7 +97,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'classifies the substring package as transitive', :aggregate_failures do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(have_key('Alamofire'))
       expect(packages['Alamofire'].dependency).to(be(true))
     end
@@ -111,7 +121,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'handles repositories with no license', :aggregate_failures do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(have_key('Alamofire'))
       expect(packages['Alamofire'].license).to(be_nil)
     end
@@ -135,7 +145,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'skips private repositories' do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(be_empty)
     end
   end
@@ -162,7 +172,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'supports old format' do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(have_key('Alamofire'))
     end
   end
@@ -175,40 +185,38 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'skips non-200 responses' do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(be_empty)
     end
   end
 
   context 'when Package.swift does not exist but Tuist Dependencies.swift does' do
+    let(:manifest_name) { 'Tuist/Dependencies.swift' }
+    let(:resolved_name) { 'Tuist/Package.resolved'   }
+
     before do
-      allow(File).to(receive(:read).with('Tuist/Package.resolved').and_return(resolved_file))
-      allow(File).to(receive(:exist?).with('Tuist/Package.swift').and_return(false))
-      allow(File).to(receive(:exist?).with('Tuist/Dependencies.swift').and_return(true))
-      allow(File).to(receive(:read).with('Tuist/Dependencies.swift').and_return(main_file_content))
       stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
         .to_return(status: 200, body: github_response)
     end
 
     it 'uses Tuist Dependencies.swift as main file' do
       packages = {}
-      parser.parse('Tuist/Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(have_key('Alamofire'))
     end
   end
 
   context 'when only xcodeproj exists' do
+    let(:manifest_name) { 'Package.xcodeproj/project.pbxproj' }
+
     before do
-      allow(File).to(receive(:exist?).with('Package.swift').and_return(false))
-      allow(File).to(receive(:exist?).with('Package.xcodeproj/project.pbxproj').and_return(true))
-      allow(File).to(receive(:read).with('Package.xcodeproj/project.pbxproj').and_return(main_file_content))
       stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
         .to_return(status: 200, body: github_response)
     end
 
     it 'uses xcodeproj as main file' do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(have_key('Alamofire'))
     end
   end
@@ -243,32 +251,31 @@ RSpec.describe(SOUP::SPMParser) do
     # Regression test for BUG-011: a previous implementation used
     # file.split('.').first to derive the xcodeproj path, which truncated
     # any path whose parent directory contained a dot.
+    # A real directory literally named "foo.bar" on disk, so the path genuinely
+    # contains the dot that the old split('.').first truncated at.
+    let(:manifest_name) { 'foo.bar/MyProject/Package.xcodeproj/project.pbxproj' }
+    let(:resolved_name) { 'foo.bar/MyProject/Package.resolved'                  }
+
     before do
-      allow(File).to(receive(:read).with('/Users/foo.bar/MyProject/Package.resolved').and_return(resolved_file))
-      allow(File).to(receive(:exist?).with('/Users/foo.bar/MyProject/Package.swift').and_return(false))
-      allow(File).to(receive(:exist?).with('/Users/foo.bar/MyProject/Package.xcodeproj/project.pbxproj').and_return(true))
-      allow(File).to(receive(:read).with('/Users/foo.bar/MyProject/Package.xcodeproj/project.pbxproj').and_return(main_file_content))
       stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')
         .to_return(status: 200, body: github_response)
     end
 
     it 'resolves the xcodeproj sibling path without truncating at the first dot', :aggregate_failures do
       packages = {}
-      expect { parser.parse('/Users/foo.bar/MyProject/Package.resolved', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
       expect(packages).to(have_key('Alamofire'))
     end
   end
 
   context 'when no main file exists' do
-    before do
-      allow(File).to(receive(:exist?).with('Package.swift').and_return(false))
-      allow(File).to(receive(:exist?).with('Package.xcodeproj/project.pbxproj').and_return(false))
-    end
+    # No Swift manifest of any name is written to the fixture dir.
+    let(:manifest_name) { nil }
 
     it 'raises a SOUP::InvalidLockfileError naming the file' do
       packages = {}
-      expect { parser.parse('Package.resolved', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(SOUP::InvalidLockfileError, /No Swift main file found/))
     end
   end
@@ -293,7 +300,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'handles git@ repository URLs' do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(have_key('Alamofire'))
     end
   end
@@ -306,7 +313,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'raises on rate limit' do
       packages = {}
-      expect { parser.parse('Package.resolved', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(SOUP::RateLimitError, /rate limit/))
     end
   end
@@ -326,7 +333,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'raises on rate limit even when the reason phrase does not contain the keyword' do
       packages = {}
-      expect { parser.parse('Package.resolved', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(SOUP::RateLimitError, /rate limit/))
     end
   end
@@ -343,7 +350,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'warns with status + url + package context and omits the package', :aggregate_failures do
       packages = {}
-      expect { parser.parse('Package.resolved', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(output(%r{HTTP 502 .*package=alamofire.*url=https://api\.github\.com/repos/Alamofire/Alamofire.*body=<html>upstream timeout</html>}m).to_stderr)
       expect(packages).to(be_empty)
     end
@@ -369,7 +376,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'records the branch as the pin identifier so the SOUP entry is not blank' do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['Alamofire'].version).to(eq('main'))
     end
   end
@@ -394,7 +401,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'falls back to the revision when neither version nor branch is set' do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['Alamofire'].version).to(eq('deadbeef'))
     end
   end
@@ -408,7 +415,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'raises on bad credentials' do
       packages = {}
-      expect { parser.parse('Package.resolved', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(SOUP::AuthenticationError, /Bad credentials/))
     end
   end
@@ -419,37 +426,37 @@ RSpec.describe(SOUP::SPMParser) do
     let(:packages) { {} }
 
     context 'with empty Package.resolved content' do
-      before { allow(File).to(receive(:read).with('Package.resolved').and_return('')) }
+      let(:resolved_file) { '' }
 
       it 'raises JSON::ParserError' do
-        expect { parser.parse('Package.resolved', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(raise_error(JSON::ParserError))
       end
     end
 
     context 'with truncated JSON in Package.resolved' do
-      before { allow(File).to(receive(:read).with('Package.resolved').and_return('{"pins":[{"identity":"alamofire"')) }
+      let(:resolved_file) { '{"pins":[{"identity":"alamofire"' }
 
       it 'raises JSON::ParserError' do
-        expect { parser.parse('Package.resolved', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(raise_error(JSON::ParserError))
       end
     end
 
     context 'with non-JSON garbage in Package.resolved' do
-      before { allow(File).to(receive(:read).with('Package.resolved').and_return('not json')) }
+      let(:resolved_file) { 'not json' }
 
       it 'raises JSON::ParserError' do
-        expect { parser.parse('Package.resolved', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(raise_error(JSON::ParserError))
       end
     end
 
     context 'with valid JSON but empty pins array' do
-      before { allow(File).to(receive(:read).with('Package.resolved').and_return('{"pins":[]}')) }
+      let(:resolved_file) { '{"pins":[]}' }
 
       it 'parses without raising and adds no packages', :aggregate_failures do
-        expect { parser.parse('Package.resolved', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .not_to(raise_error)
         expect(packages).to(be_empty)
       end
@@ -458,24 +465,20 @@ RSpec.describe(SOUP::SPMParser) do
     # TEST-05: race where Dir.glob found the lockfile but it was deleted /
     # unreadable before File.read ran.
     context 'when Package.resolved cannot be read' do
-      before do
-        allow(File).to(
-          receive(:read)
-                    .with('Package.resolved').and_raise(Errno::ENOENT.new('Package.resolved'))
-        )
-      end
+      # A path inside the fixture dir that was never written, so the real
+      # File.read raises ENOENT instead of a stub simulating it.
+      let(:lockfile_path) { File.join(fixture_dir, 'gone', 'Package.resolved') }
 
       it 'surfaces Errno::ENOENT' do
-        expect { parser.parse('Package.resolved', packages) }
+        expect { parser.parse(lockfile_path, packages) }
           .to(raise_error(Errno::ENOENT))
       end
     end
 
-    # TEST-12 follow-up: parser exercised against real Package.resolved bytes
-    # via SoupFixtureHelpers, demonstrating the no-stub pattern for spm.
-    context 'with real Package.resolved + Package.swift fixtures on disk' do
+    # TEST-12: a well-formed Package.resolved plus sibling Package.swift, read
+    # straight off disk with the full GitHub metadata response.
+    context 'with a well-formed Package.resolved on disk' do
       before do
-        allow(File).to(receive(:exist?).and_call_original)
         body = {
           name: 'Alamofire',
           private: false,
@@ -488,8 +491,6 @@ RSpec.describe(SOUP::SPMParser) do
       end
 
       it 'reads Package.resolved + sibling Package.swift from disk without File stubs' do
-        write_fixture('Package.swift', '.package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0")')
-        lockfile_path = write_fixture('Package.resolved', resolved_file)
         parser.parse(lockfile_path, packages)
         expect(packages['Alamofire']).to(have_attributes(language: 'Swift', version: '5.9.0', license: 'MIT'))
       end
@@ -532,10 +533,33 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'parses all 100 pins without raising and adds them to the hash', :aggregate_failures do
       packages = {}
-      parser.parse('Package.resolved', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages.size).to(eq(100))
       expect(packages['pkg-1']).to(have_attributes(language: 'Swift', version: '1.0.0', license: 'MIT'))
       expect(packages['pkg-100']).to(have_attributes(language: 'Swift', version: '1.0.0', license: 'MIT'))
+    end
+  end
+
+  # CONS-007: the dir == '.' branch was previously covered only incidentally, by
+  # specs that stubbed File.read and so passed 'Package.resolved' rather than a
+  # real path. Now that every fixture is an absolute tmpdir path, the helper is
+  # asserted directly, the same way base_parser_spec exposes BaseParser's own
+  # protected helpers.
+  describe '#path_join' do
+    subject(:helper) { helper_class.new }
+
+    let(:helper_class) do
+      Class.new(described_class) do
+        public :path_join
+      end
+    end
+
+    it 'returns the bare suffix when the directory is "."' do
+      expect(helper.path_join('.', 'Package.swift')).to(eq('Package.swift'))
+    end
+
+    it 'joins the suffix onto a real directory without a leading "./"' do
+      expect(helper.path_join('/tmp/proj', 'Package.swift')).to(eq('/tmp/proj/Package.swift'))
     end
   end
 end

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe(SOUP::YarnParser) do
   end
 
   let(:main_file) { '{"dependencies":{"lodash":"^4.17.0"}}' }
-
   let(:registry_response) do
     {
       versions: {
@@ -23,10 +22,22 @@ RSpec.describe(SOUP::YarnParser) do
     }.to_json
   end
 
+  # TEST-12: both the lockfile and its sibling package.json are written to a
+  # per-example tmpdir, so the parser resolves package.json through the same
+  # sibling_file path handling production uses instead of a File.read stub keyed
+  # to a bare basename.
+  def lockfile_path
+    write_fixture('package.json', main_file)
+    write_fixture('yarn.lock', yarn_lock_content)
+  end
+
+  def yarn_lock_content = "# yarn lockfile v1\n"
+
+  # YarnLockParser is third-party, not File, stubbing -- it stays, but is keyed
+  # to the real fixture path. Contexts that want the library to actually run
+  # re-stub this same constraint with and_call_original.
   before do
-    allow(YarnLockParser::Parser).to(receive(:parse).with('yarn.lock').and_return(parsed_lock))
-    allow(File).to(receive(:read).and_call_original)
-    allow(File).to(receive(:read).with('package.json').and_return(main_file))
+    allow(YarnLockParser::Parser).to(receive(:parse).with(lockfile_path).and_return(parsed_lock))
   end
 
   context 'with successful registry response' do
@@ -37,7 +48,7 @@ RSpec.describe(SOUP::YarnParser) do
 
     it 'parses via YarnLockParser and calls NPM registry', :aggregate_failures do
       packages = {}
-      parser.parse('yarn.lock', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['lodash'].language).to(eq('JS'))
       expect(packages['lodash'].version).to(eq('4.17.21'))
       expect(packages['lodash'].license).to(eq('MIT'))
@@ -58,22 +69,17 @@ RSpec.describe(SOUP::YarnParser) do
 
     it 'classifies the substring package as transitive' do
       packages = {}
-      parser.parse('yarn.lock', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['lodash'].dependency).to(be(true))
     end
   end
 
   context 'when package.json has vendor dependency' do
-    before do
-      allow(File).to(
-        receive(:read).with('package.json')
-                                         .and_return('{"dependencies":{"lodash": "file:vendor/lodash"}}')
-      )
-    end
+    let(:main_file) { '{"dependencies":{"lodash": "file:vendor/lodash"}}' }
 
     it 'skips vendor packages' do
       packages = {}
-      parser.parse('yarn.lock', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(be_empty)
     end
   end
@@ -82,7 +88,7 @@ RSpec.describe(SOUP::YarnParser) do
     stub_request(:get, 'https://registry.npmjs.org/lodash')
       .to_return(status: 500, body: 'Server Error')
     packages = {}
-    expect { parser.parse('yarn.lock', packages) }
+    expect { parser.parse(lockfile_path, packages) }
       .to(raise_error(SOUP::RegistryError, /HTTP 500.*lodash.*registry\.npmjs\.org/m))
   end
 
@@ -90,18 +96,18 @@ RSpec.describe(SOUP::YarnParser) do
   # "Aborting after N retries" warning before the parser skipped the
   # package, not just that parse did not raise.
   context 'when the registry times out' do
-    let(:url) { 'https://registry.npmjs.org/lodash' }
-    let(:packages) { {} }
+    let(:url)      { 'https://registry.npmjs.org/lodash' }
+    let(:packages) { {}                                  }
 
     before { stub_request(:get, url).to_timeout }
 
     it 'emits the "Aborting after N retries" stderr warning' do
-      expect { parser.parse('yarn.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(output(/Aborting after \d+ retries/).to_stderr)
     end
 
     it 'retries max_retries+1 times before skipping the package', :aggregate_failures do
-      parser.parse('yarn.lock', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages).to(be_empty)
       expect(a_request(:get, url)).to(have_been_made.times(SOUP::HttpClient.max_retries + 1))
     end
@@ -110,7 +116,7 @@ RSpec.describe(SOUP::YarnParser) do
     # BaseParser#npm_registry_response, named from the `label` this parser
     # passes. A timeout is skipped here even though a non-200 raises.
     it 'names the package as name@version in the skip warning' do
-      expect { parser.parse('yarn.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(output(/Skipping lodash@4\.17\.21: network timeout after retries/).to_stderr)
     end
   end
@@ -131,7 +137,7 @@ RSpec.describe(SOUP::YarnParser) do
 
     it 'skips the package instead of crashing on nil license access', :aggregate_failures do
       packages = {}
-      expect { parser.parse('yarn.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
       expect(packages).to(be_empty)
     end
@@ -145,7 +151,7 @@ RSpec.describe(SOUP::YarnParser) do
 
     it 'skips the package instead of raising', :aggregate_failures do
       packages = {}
-      expect { parser.parse('yarn.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
       expect(packages).to(be_empty)
     end
@@ -157,12 +163,12 @@ RSpec.describe(SOUP::YarnParser) do
     # in yarn.rb#parse the next line raises NoMethodError on NilClass and
     # the whole run aborts.
     before do
-      allow(YarnLockParser::Parser).to(receive(:parse).with('yarn.lock').and_return(nil))
+      allow(YarnLockParser::Parser).to(receive(:parse).with(lockfile_path).and_return(nil))
     end
 
     it 'raises a clear unsupported-format error', :aggregate_failures do
       packages = {}
-      expect { parser.parse('yarn.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(SOUP::UnsupportedFormatError, /Unsupported yarn\.lock format/))
       expect(packages).to(be_empty)
     end
@@ -188,7 +194,7 @@ RSpec.describe(SOUP::YarnParser) do
 
     it 'converts Unlicense to NOASSERTION' do
       packages = {}
-      parser.parse('yarn.lock', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages['lodash'].license).to(eq('NOASSERTION'))
     end
   end
@@ -218,7 +224,7 @@ RSpec.describe(SOUP::YarnParser) do
 
     it 'normalizes the object form to its type string instead of crashing', :aggregate_failures do
       packages = {}
-      expect { parser.parse('yarn.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
       expect(packages['lodash'].license).to(eq('MIT'))
     end
@@ -228,20 +234,19 @@ RSpec.describe(SOUP::YarnParser) do
   # unreadable before YarnLockParser::Parser.parse ran.
   context 'when yarn.lock cannot be read' do
     before do
-      allow(YarnLockParser::Parser).to(receive(:parse).with('yarn.lock').and_raise(Errno::ENOENT.new('yarn.lock')))
+      allow(YarnLockParser::Parser).to(receive(:parse).with(lockfile_path).and_raise(Errno::ENOENT.new('yarn.lock')))
     end
 
     it 'surfaces Errno::ENOENT' do
       packages = {}
-      expect { parser.parse('yarn.lock', packages) }
+      expect { parser.parse(lockfile_path, packages) }
         .to(raise_error(Errno::ENOENT))
     end
   end
 
-  # TEST-12: parser exercised against real lockfile bytes written to a
-  # Dir.mktmpdir via SoupFixtureHelpers, exactly like Application#detect_packages
-  # would invoke it in production. Demonstrates the new pattern; follow-up
-  # work will migrate the remaining parsers spec-by-spec.
+  # TEST-12: parser exercised against real lockfile bytes, with the real
+  # YarnLockParser running, exactly like Application#detect_packages would
+  # invoke it in production.
   context 'with a real yarn.lock fixture on disk' do
     let(:yarn_lock_content) do
       <<~LOCK
@@ -254,19 +259,15 @@ RSpec.describe(SOUP::YarnParser) do
       LOCK
     end
 
-    let(:package_json_content) { '{"dependencies":{"lodash":"^4.17.0"}}' }
-
     before do
       # Let the real YarnLockParser run against on-disk bytes instead of the
-      # literal-path stub from the outer `before`.
-      allow(YarnLockParser::Parser).to(receive(:parse).and_call_original)
-      write_fixture('package.json', package_json_content)
+      # canned parsed_lock from the outer `before`.
+      allow(YarnLockParser::Parser).to(receive(:parse).with(lockfile_path).and_call_original)
       stub_request(:get, 'https://registry.npmjs.org/lodash')
         .to_return(status: 200, body: registry_response)
     end
 
     it 'reads the lockfile and writes a Package entry without File stubs' do
-      lockfile_path = write_fixture('yarn.lock', yarn_lock_content)
       packages = {}
       parser.parse(lockfile_path, packages)
       expect(packages['lodash']).to(have_attributes(language: 'JS', version: '4.17.21', license: 'MIT'))
@@ -279,12 +280,10 @@ RSpec.describe(SOUP::YarnParser) do
   # Yarn Berry case (BUG-01) but via a real on-disk file rather than a stub.
   context 'with an empty yarn.lock fixture on disk' do
     let(:packages) { {} }
-    let(:lockfile_path) do
-      write_fixture('package.json', '{}')
-      write_fixture('yarn.lock', '')
-    end
+    let(:main_file)         { '{}' }
+    let(:yarn_lock_content) { ''   }
 
-    before { allow(YarnLockParser::Parser).to(receive(:parse).and_call_original) }
+    before { allow(YarnLockParser::Parser).to(receive(:parse).with(lockfile_path).and_call_original) }
 
     it 'raises UnsupportedFormatError when YarnLockParser cannot parse the file', :aggregate_failures do
       expect { parser.parse(lockfile_path, packages) }
@@ -315,7 +314,7 @@ RSpec.describe(SOUP::YarnParser) do
 
     it 'parses all 100 packages without raising and adds them to the hash', :aggregate_failures do
       packages = {}
-      parser.parse('yarn.lock', packages)
+      parser.parse(lockfile_path, packages)
       expect(packages.size).to(eq(100))
       expect(packages['pkg-1']).to(have_attributes(language: 'JS', version: '1.0.0', license: 'MIT'))
       expect(packages['pkg-100']).to(have_attributes(language: 'JS', version: '1.0.0', license: 'MIT'))


### PR DESCRIPTION
## Summary

`spec/spec_helper.rb` documents the TEST-12 convention — write parser fixtures into a per-example tmpdir "instead of stubbing File.read / File.foreach / File.readlines" — yet ~53 File stubs remained across 7 spec files, often in the same files that already used `write_fixture`. New specs therefore had two competing patterns to copy, and the stubbed one bypassed the real `sibling_file` path handling.

There is now **zero File stubbing anywhere in `spec/`** — no `receive(:read)`, `:readlines`, `:foreach`, or `:exist?`.

**Key changes:**

- `spec/soup/gradle_parser_spec.rb` (12 read + 8 readlines), `spec/soup/spm_parser_spec.rb` (12 read + 11 exist?), `spec/soup/pip_parser_spec.rb` (6 read + 14 foreach + 8 exist?), `spec/soup/composer_parser_spec.rb` (6 read), `spec/soup/npm_parser_spec.rb` (4 read), `spec/soup/application_spec.rb` (3 read), `spec/soup/yarn_parser_spec.rb` (2 read): all converted to `write_fixture` tmpdir fixtures
- `spec/soup/base_parser_spec.rb`: added a direct `#sibling_file` describe block (3 examples)
- `spec/soup/spm_parser_spec.rb`: added a direct `#path_join` describe block (2 examples)

Scope was widened past the issue's literal "read/readlines" to include `foreach` and `exist?`. PIP drove its parsing entirely through `foreach` stubs, so converting only its `read` calls would have left that file still mixing both patterns — the exact problem this issue exists to fix. Out-of-scope stubbing is deliberately preserved: `ENV` (spm), `Dir.glob` (application — `detect_packages` globs `Dir.pwd`), and `YarnLockParser` (third-party).

### Why two helper specs were added

After the migration, branch coverage dropped by exactly 2: `base.rb:64` and `spm.rb:75`, both the `dir == '.'` branch of a sibling-path helper. Those branches were only ever reached because the old stubs passed bare basenames like `'composer.lock'` — `sibling_file`'s own comment says it exists "so File.read stubs and callers that pass bare basenames keep working". Production always passes absolute paths from `Dir.glob`, so completing the migration stranded them.

Coverage was restored by asserting both helpers directly rather than by leaving stubs behind, so the branch is now covered on purpose instead of incidentally. `#path_join` uses the anonymous-subclass pattern `base_parser_spec.rb` already uses to expose non-public helpers.

### Tests that got genuinely stronger

- Composer's `"lock"`-in-directory regression (BUG-04) now writes a real `sherlock/proj/` directory instead of stubbing a fake path, so the path actually contains the substring the old `gsub` corrupted
- SPM's dot-in-directory regression (BUG-011) likewise uses a real `foo.bar/MyProject/` directory
- Gradle's `build.gradle.kts` fallback and SPM's manifest-discovery chain are now expressed by which files exist on disk, exercising the real `File.exist?` walk rather than a stubbed one
- Five "cannot be read" tests replaced `and_raise(Errno::ENOENT)` with a genuinely absent path, so the real error surfaces

### Lint

`RSpec/MultipleMemoizedHelpers` fired 73 times, because a fixture-path helper per group is inherent to the pattern. Resolved with `def` helpers — already this repo's spec convention (`stub_composer_files`, `write`, `registry_body`) and not counted by that cop — rather than relaxing `.rubocop.yml`. No lint config change was needed.

Verification against a recorded pre-change baseline: examples 265 -> 270 (the 5 new helper examples; none lost), line coverage **identical** at 718/727 (98.76%), branch coverage **identical** at 245/275 (89.09%), RuboCop clean across all 39 files.

Closes #384

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
