### PR TITLE
#383: scope DEPENDENCY_TEXT to module SOUP as a private constant

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@
 **Key Components:**
 
 - `PARSER_REGISTRY`: Private module-level constant (`module SOUP`) mapping lock file names to parser classes and skip flags
-- `DEPENDENCY_TEXT`: Top-level constant holding the value written into `requirements` and `verification_reasoning` for transitive dependencies
+- `DEPENDENCY_TEXT`: Private module-level constant (`module SOUP`) holding the value written into `requirements` and `verification_reasoning` for transitive dependencies
 - `initialize(argv)`: Configures options and initializes state
 - `execute`: Main entry point that runs the detection, checking, and output workflow. Uses an `ensure` block to persist partial state on failure
 - `validate_config!`: Validates that configuration files exist and contain valid JSON

--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -21,9 +21,10 @@ require_relative 'parsers/spm'
 require_relative 'parsers/yarn'
 require_relative 'status'
 
-DEPENDENCY_TEXT = 'Dependency'
-
 module SOUP
+  DEPENDENCY_TEXT = 'Dependency'
+  private_constant :DEPENDENCY_TEXT
+
   PARSER_REGISTRY = {
     'buildscript-gradle.lockfile': { parser: GradleParser, skip: :skip_gradle },
     'composer.lock': { parser: ComposerParser, skip: :skip_composer },

--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -153,6 +153,24 @@ RSpec.describe(SOUP::Application) do
     '{"require":{"valid/pkg":"^1.0","bad/pkg":"^2.0","excepted-pkg":"^3.0","noassert/pkg":"^4.0"}}'
   end
 
+  # CONS-006 regression: DEPENDENCY_TEXT used to be defined at the top level of
+  # application.rb, so merely requiring soup leaked ::DEPENDENCY_TEXT into the
+  # host program's Object namespace. It is now module-scoped and private, like
+  # PARSER_REGISTRY below. The value itself stays covered by the markdown-output
+  # example that asserts a transitive package renders "Dependency".
+  describe 'DEPENDENCY_TEXT' do
+    it 'does not leak into the global Object namespace' do
+      expect(Object.const_defined?(:DEPENDENCY_TEXT)).to(be(false))
+    end
+
+    # Qualified access is what private_constant actually guards; Module#const_get
+    # deliberately bypasses it, so asserting on const_get would pass either way.
+    it 'is private on SOUP rather than publicly reachable' do
+      expect { SOUP::DEPENDENCY_TEXT.to_s }
+        .to(raise_error(NameError, /private constant/))
+    end
+  end
+
   # COM-001 regression: detect_packages used to carry a `next if
   # config[:parser].nil?` guard justified by a Podfile.lock entry that no longer
   # exists in the registry. The guard was removed as dead code, which is only


### PR DESCRIPTION
## Summary

`DEPENDENCY_TEXT` was defined at the top level of `application.rb`, outside `module SOUP` and with no visibility declaration — so merely requiring soup leaked `::DEPENDENCY_TEXT` into the host program's `Object` namespace. Every other constant in the codebase is module-scoped and explicitly declared; `PARSER_REGISTRY`, immediately below it, is even `private_constant`.

Verified before acting: there are exactly 4 usages (`application.rb` 215/216/233/241), all inside `class Application`, which is lexically nested in `module SOUP`. No spec, `bin/`, or external reference exists, so `private_constant` is safe — `PARSER_REGISTRY`, used the same way from inside `Application`, already proves the pattern works.

**Key changes:**

- `lib/soup/application.rb`: moved `DEPENDENCY_TEXT` inside `module SOUP` and added `private_constant :DEPENDENCY_TEXT`, placed above `PARSER_REGISTRY` to match its style
- `docs/architecture.md`: line 112 described it as a "Top-level constant", which this change makes factually wrong. It now reads "Private module-level constant (`module SOUP`)", matching the `PARSER_REGISTRY` line directly above it. Not in the issue's scope list, but leaving it would ship stale documentation about the very constant being moved
- `spec/soup/application_spec.rb`: added two regression examples — one asserting `Object.const_defined?(:DEPENDENCY_TEXT)` is `false` (no global namespace leak, the issue's stated goal), one asserting qualified access raises `NameError` matching `/private constant/`

### Note for reviewers on the second test

The first attempt asserted privacy via `SOUP.const_get(:DEPENDENCY_TEXT)` — and it failed. `Module#const_get` deliberately **bypasses** `private_constant`; it returns `PARSER_REGISTRY` too, so this is Ruby's behaviour rather than a defect here. Qualified access is what `private_constant` actually guards.

That matters: an assertion on `const_get` would have passed whether or not the constant was private — a vacuous test. The spec asserts qualified access instead, with a comment recording why so the next person does not "simplify" it back.

Both examples were confirmed load-bearing by reverting the change; they failed with `uninitialized constant SOUP::DEPENDENCY_TEXT` and `expected false`.

Verification: full suite 272 examples, 0 failures (270 before, plus the 2 new); line coverage 719/728 (98.76%, unchanged percentage); branch coverage 245/275 (89.09%, unchanged); RuboCop clean across all 39 files; markdownlint-cli2 with the repo's `.markdownlint-cli2.yaml` reports 0 issues.

Closes #383

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
