### PR TITLE
#382: anchor the requirements.in path substitution in the PIP parser

### DIFF
--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -52,7 +52,11 @@ module SOUP
     # comparison; an empty list (no .in file) leaves every package transitive,
     # matching the previous empty-main_file behavior.
     def read_direct_dependencies(file)
-      in_file = file.gsub('.txt', '.in')
+      # Anchored so a path that merely contains ".txt" (e.g. /builds/my.txt.d/
+      # requirements.txt) is not corrupted, matching the gradle idiom. The .in
+      # file keeps the lockfile's name stem (dev-requirements.txt ->
+      # dev-requirements.in), so sibling_file's fixed-name form does not fit.
+      in_file = file.sub(/\.txt\z/, '.in')
       return [] unless File.exist?(in_file)
 
       File.read(in_file).each_line.filter_map do |line|

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -121,6 +121,37 @@ RSpec.describe(SOUP::PIPParser) do
     end
   end
 
+  # CONS-003 regression: the sibling .in path used to be derived with an
+  # unanchored `file.gsub('.txt', '.in')`, which rewrote every ".txt" in the
+  # whole path -- so /builds/my.txt.d/requirements.txt looked for
+  # /builds/my.in.d/requirements.in. That file never exists, so
+  # read_direct_dependencies silently returned [] and every Python package was
+  # misclassified as transitive with no warning. A real directory named
+  # "my.txt.d" is written here so the path genuinely contains the substring.
+  context 'when the lockfile lives in a directory whose name contains ".txt"' do
+    let(:requirements_in_content) { "requests\n"                       }
+    let(:requirements_content)    { "requests==2.31.0\nflask==3.0.0\n" }
+
+    def requirements_path
+      write_fixture('my.txt.d/requirements.in', requirements_in_content)
+      write_fixture('my.txt.d/requirements.txt', requirements_content)
+    end
+
+    before do
+      stub_request(:get, 'https://pypi.org/pypi/requests/json')
+        .to_return(status: 200, body: requests_response)
+      stub_request(:get, 'https://pypi.org/pypi/flask/json')
+        .to_return(status: 200, body: flask_response)
+    end
+
+    it 'still resolves the sibling requirements.in without corrupting the path', :aggregate_failures do
+      packages = {}
+      parser.parse(requirements_path, packages)
+      expect(packages['requests'].dependency).to(be(false))
+      expect(packages['flask'].dependency).to(be(true))
+    end
+  end
+
   # BUG-003 regression: a transitive package whose name is a substring of a
   # declared requirement (requests within requests-oauthlib) must NOT be flagged
   # direct. The old String#include? scan of requirements.in mis-classified it.


### PR DESCRIPTION
## Summary

`read_direct_dependencies` derived the sibling `requirements.in` with `file.gsub('.txt', '.in')` — an unanchored, global substring replacement applied to the **whole path**. A lockfile at `/builds/my.txt.d/requirements.txt` was rewritten to `/builds/my.in.d/requirements.in`, which never exists: `File.exist?` returned false, the method returned `[]`, and **every Python package was silently misclassified as transitive** with no warning.

That makes this a data-correctness defect with a silent failure mode rather than a style issue — the SOUP register would quietly show direct dependencies as transitive, and transitive packages get auto-filled metadata instead of being reviewed.

**Key changes:**

- `lib/soup/parsers/pip.rb`: now uses `file.sub(/\.txt\z/, '.in')`, matching the established anchored idiom in `gradle.rb:59` (`file.sub(/(?:buildscript-)?gradle\.lockfile\z/, name)`). Added a comment explaining why it is anchored and why `BaseParser#sibling_file`'s fixed-name form does not fit
- `spec/soup/pip_parser_spec.rb`: added the CONS-003 regression test, which writes a **real** directory named `my.txt.d` to disk (per the TEST-12 convention adopted in #384) rather than stubbing a fake path, so the path genuinely contains the `.txt` substring

### The regression test reproduces the defect

With the old `gsub` restored, it fails with exactly the described symptom:

```
expect(packages['requests'].dependency).to(be(false))
  expected false
       got true
```

`requests` is declared in `requirements.in`, so it must be direct; the corrupted path made every package transitive. Only that one assertion fails — `flask` is transitive either way — so the test isolates the misclassification rather than passing by luck.

### Note for reviewers

The issue's Out of Scope section justifies avoiding `sibling_file` by saying the `.in` file keeps the lockfile's name stem (`dev-requirements.txt` → `dev-requirements.in`). That case is not reachable today: `PARSER_REGISTRY` registers only `requirements.txt`, and `Dir.glob("**/requirements.txt")` does not match `dev-requirements.txt` (verified empirically), so the parser only ever receives files named exactly `requirements.txt`.

The anchored `sub` was kept anyway: it matches the gradle idiom and stays correct if such a registry entry is ever added, whereas `sibling_file(file, 'requirements.in')` would silently read the wrong file in that future.

Verification: full suite 273 examples, 0 failures (272 before, plus the 1 new); line coverage 719/728 (98.76%) and branch coverage 245/275 (89.09%), both unchanged; RuboCop clean across all 39 files.

Closes #382

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
