### PR TITLE
#381: route every registry request through a shared timeout-safe helper

### DIFF
--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -121,23 +121,34 @@ module SOUP
       "#{NPM_REGISTRY_ROOT}/#{name}"
     end
 
-    # GET a package's npm packument, absorbing the post-retry timeout that all
-    # three npm consumers (NPM, Yarn, Importmap) treat identically: warn and
-    # omit the package rather than kill the scan. Returns nil in that case, so
-    # callers guard with `return if response.nil?`.
+    # GET a registry URL, absorbing the timeout HttpClient re-raises once its
+    # retries are exhausted. Parallel.map propagates the first exception and
+    # aborts every other in-flight lookup, so one unreachable registry must not
+    # kill the whole scan. Returns nil on timeout, so callers guard with
+    # `return if response.nil?` -- or, for a multi-source loop, fall through to
+    # the next source. Every parser that talks to a registry routes through here.
     #
-    # `label` is what the warning names the package as -- NPM and Yarn know the
-    # version up front and pass "name@version", while Importmap resolves the
-    # version from this very response and so can only name the package.
+    # `label` names what is being skipped: the package for the single-source
+    # parsers, the URL itself for gradle's mirror loop. `outcome` states what
+    # happens next, because a timeout omits the package for most parsers but for
+    # gradle only advances to the next repository -- claiming omission there
+    # would be false whenever a later mirror resolves the coordinate.
     #
-    # Deliberately stops short of the non-200 branch: NPM and Importmap warn and
-    # skip there, Yarn raises RegistryError and aborts the run. Unifying that
-    # split is CONS-001, so each caller keeps its own policy.
-    def npm_registry_response(name:, label: name)
-      HttpClient.get(npm_registry_url(name))
+    # Deliberately stops short of the non-200 branch: the parsers disagree on
+    # whether that warns-and-skips or raises, and unifying it is CONS-001.
+    def registry_response(url, label:, outcome: 'package omitted from SOUP', **)
+      HttpClient.get(url, **)
     rescue Net::OpenTimeout, Net::ReadTimeout => e
-      warn("Skipping #{label}: network timeout after retries (#{e.message}); package omitted from SOUP")
+      warn("Skipping #{label}: network timeout after retries (#{e.message}); #{outcome}")
       nil
+    end
+
+    # Convenience wrapper for the three npm consumers (NPM, Yarn, Importmap),
+    # which all resolve the same packument URL from a package name. NPM and Yarn
+    # know the version up front and pass "name@version"; Importmap resolves the
+    # version from this very response and so can only name the package.
+    def npm_registry_response(name:, label: name)
+      registry_response(npm_registry_url(name), label: label)
     end
 
     # Build a Package from an npm-registry per-version payload. The three npm

--- a/lib/soup/parsers/bundler.rb
+++ b/lib/soup/parsers/bundler.rb
@@ -22,18 +22,25 @@ module SOUP
     private
 
     def fetch_package(file, direct_deps, spec)
+      label = "#{spec.name} #{spec.version}"
       version_url = "https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{spec.version}.json"
-      response = HttpClient.get(version_url)
+      # A timeout means rubygems.org is unreachable after every retry, so the
+      # remaining fallbacks would time out too -- skip the gem rather than walk
+      # the rest of the chain. CONS-002.
+      response = registry_response(version_url, label: label)
+      return if response.nil?
 
       if response.code != 200
         latest_url = "https://api.rubygems.org/api/v1/versions/#{spec.name}/latest.json"
-        response = HttpClient.get(latest_url)
+        response = registry_response(latest_url, label: label)
+        return if response.nil?
 
-        raise(RegistryError, http_error_message(response, url: latest_url, package: "#{spec.name} #{spec.version}")) unless response.code == 200
+        raise(RegistryError, http_error_message(response, url: latest_url, package: label)) unless response.code == 200
 
         latest_version = JSON.parse(response.body)['version']
         fallback_url = "https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{latest_version}.json"
-        response = HttpClient.get(fallback_url)
+        response = registry_response(fallback_url, label: "#{spec.name} #{latest_version}")
+        return if response.nil?
 
         raise(RegistryError, http_error_message(response, url: fallback_url, package: "#{spec.name} #{latest_version}")) unless response.code == 200
       end

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -72,7 +72,7 @@ module SOUP
       # still try the per-repository POM fallbacks below (maven.google.com et al.
       # serve the Android/AndroidX artifacts that dominate a Gradle scan), so a
       # dead primary is treated as "no match" rather than aborting the whole run.
-      response = safe_get(last_url)
+      response = registry_response(last_url, label: last_url, outcome: 'trying the per-repository POM fallbacks')
 
       parsed = JSON.parse(response.body) if response&.code == 200
       docs = parsed&.dig('response', 'docs')
@@ -87,7 +87,7 @@ module SOUP
       else
         REPOSITORY_URLS.each do |url|
           last_url = "#{url}/#{group_id.tr('.', '/')}/#{artifact_id}/#{version}/#{artifact_id}-#{version}.pom"
-          response = safe_get(last_url)
+          response = registry_response(last_url, label: last_url, outcome: 'trying the next repository')
 
           next unless response&.code == 200
 
@@ -116,18 +116,6 @@ module SOUP
         website: website,
         dependency: !manifest_mentions?(main_file, "#{group_id}:#{artifact_id}")
       )
-    end
-
-    # HttpClient.get re-raises Net::OpenTimeout/Net::ReadTimeout once its retries
-    # are exhausted. For a multi-mirror parser an unreachable mirror should not
-    # kill the scan (Parallel.map propagates the first exception and aborts every
-    # other in-flight lookup), so we swallow the timeout, warn, and return nil so
-    # the caller falls through to the next source.
-    def safe_get(url)
-      HttpClient.get(url)
-    rescue Net::OpenTimeout, Net::ReadTimeout => e
-      warn("Error: #{e.message}. Skipping #{url} after retries.")
-      nil
     end
 
     # Build the "could not resolve this coordinate" warning. With a final

--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -77,7 +77,8 @@ module SOUP
 
     def fetch_package(file, direct_deps, pip_package, version)
       url = "https://pypi.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json"
-      response = HttpClient.get(url)
+      response = registry_response(url, label: "#{pip_package}==#{version}")
+      return if response.nil?
 
       raise(RegistryError, http_error_message(response, url: url, package: "#{pip_package}==#{version}")) unless response.code == 200
 

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -96,10 +96,12 @@ module SOUP
 
       response =
         if token.empty?
-          HttpClient.get(url)
+          registry_response(url, label: pin_id)
         else
-          HttpClient.get(url, headers: { Authorization: "token #{token}" })
+          registry_response(url, label: pin_id, headers: { Authorization: "token #{token}" })
         end
+
+      return if response.nil?
 
       unless response.code == 200
         combined = github_error_message(response)

--- a/spec/soup/bundler_parser_spec.rb
+++ b/spec/soup/bundler_parser_spec.rb
@@ -28,6 +28,28 @@ RSpec.describe(SOUP::BundlerParser) do
     allow(Bundler).to(receive(:read_file).with('Gemfile.lock').and_return(''))
   end
 
+  # CONS-002: HttpClient re-raises Net::ReadTimeout once its retries are
+  # exhausted. Before the fix that escaped fetch_package, propagated through
+  # Parallel.map, and killed the whole scan with an untyped backtrace. It must
+  # warn and omit just this gem instead.
+  context 'when the registry times out' do
+    let(:url)      { 'https://api.rubygems.org/api/v2/rubygems/test-gem/versions/1.0.0.json' }
+    let(:packages) { {}                                                                      }
+
+    before { stub_request(:get, url).to_timeout }
+
+    it 'skips the gem instead of aborting the scan', :aggregate_failures do
+      expect { parser.parse('Gemfile.lock', packages) }
+        .not_to(raise_error)
+      expect(packages).to(be_empty)
+    end
+
+    it 'names the gem in the skip warning' do
+      expect { parser.parse('Gemfile.lock', packages) }
+        .to(output(/Skipping test-gem 1\.0\.0: network timeout after retries/).to_stderr)
+    end
+  end
+
   context 'when v2 API succeeds' do
     let(:packages) { {} }
 
@@ -66,6 +88,39 @@ RSpec.describe(SOUP::BundlerParser) do
         packages = {}
         parser.parse('Gemfile.lock', packages)
         expect(packages).to(have_key('test-gem'))
+      end
+    end
+
+    # CONS-002: the fallback chain makes three sequential requests, so each has
+    # its own timeout guard. A timeout means rubygems.org is unreachable after
+    # every retry, so the remaining fallbacks would time out too -- the gem is
+    # skipped rather than walking the rest of the chain.
+    context 'when the latest-version lookup times out' do
+      let(:packages) { {} }
+
+      before { stub_request(:get, 'https://api.rubygems.org/api/v1/versions/test-gem/latest.json').to_timeout }
+
+      it 'skips the gem without attempting the remaining fallback', :aggregate_failures do
+        expect { parser.parse('Gemfile.lock', packages) }
+          .not_to(raise_error)
+        expect(packages).to(be_empty)
+        expect(a_request(:get, %r{api/v2/rubygems/test-gem/versions/2\.0\.0\.json})).not_to(have_been_made)
+      end
+    end
+
+    context 'when the resolved-version fallback times out' do
+      let(:packages) { {} }
+
+      before do
+        stub_request(:get, 'https://api.rubygems.org/api/v1/versions/test-gem/latest.json')
+          .to_return(status: 200, body: { version: '2.0.0' }.to_json)
+        stub_request(:get, 'https://api.rubygems.org/api/v2/rubygems/test-gem/versions/2.0.0.json').to_timeout
+      end
+
+      it 'skips the gem and names the resolved version in the warning', :aggregate_failures do
+        expect { parser.parse('Gemfile.lock', packages) }
+          .to(output(/Skipping test-gem 2\.0\.0: network timeout after retries/).to_stderr)
+        expect(packages).to(be_empty)
       end
     end
 

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -121,6 +121,28 @@ RSpec.describe(SOUP::PIPParser) do
     end
   end
 
+  # CONS-002: HttpClient re-raises Net::ReadTimeout once its retries are
+  # exhausted. Before the fix that escaped fetch_package, propagated through
+  # Parallel.map, and killed the whole scan with an untyped backtrace. It must
+  # warn and omit just this package instead.
+  context 'when the registry times out' do
+    let(:requirements_content) { "requests==2.31.0\n" }
+    let(:packages) { {} }
+
+    before { stub_request(:get, 'https://pypi.org/pypi/requests/json').to_timeout }
+
+    it 'skips the package instead of aborting the scan', :aggregate_failures do
+      expect { parser.parse(requirements_path, packages) }
+        .not_to(raise_error)
+      expect(packages).to(be_empty)
+    end
+
+    it 'names the package as name==version in the skip warning' do
+      expect { parser.parse(requirements_path, packages) }
+        .to(output(/Skipping requests==2\.31\.0: network timeout after retries/).to_stderr)
+    end
+  end
+
   # CONS-003 regression: the sibling .in path used to be derived with an
   # unanchored `file.gsub('.txt', '.in')`, which rewrote every ".txt" in the
   # whole path -- so /builds/my.txt.d/requirements.txt looked for

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -47,6 +47,28 @@ RSpec.describe(SOUP::SPMParser) do
     allow(ENV).to(receive(:fetch).with('GITHUB_TOKEN', '').and_return(''))
   end
 
+  # CONS-002: HttpClient re-raises Net::ReadTimeout once its retries are
+  # exhausted. Before the fix that escaped fetch_package, propagated through
+  # Parallel.map, and killed the whole scan with an untyped backtrace -- even
+  # though this parser already warn-and-skipped on a generic non-200, so it was
+  # inconsistent with itself.
+  context 'when the GitHub API times out' do
+    let(:packages) { {} }
+
+    before { stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire').to_timeout }
+
+    it 'skips the pin instead of aborting the scan', :aggregate_failures do
+      expect { parser.parse(lockfile_path, packages) }
+        .not_to(raise_error)
+      expect(packages).to(be_empty)
+    end
+
+    it 'names the pin in the skip warning' do
+      expect { parser.parse(lockfile_path, packages) }
+        .to(output(/Skipping alamofire: network timeout after retries/).to_stderr)
+    end
+  end
+
   context 'when parsing Package.resolved with GitHub API success' do
     before do
       stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire')


### PR DESCRIPTION
## Summary

`HttpClient` re-raises `Net::OpenTimeout` / `Net::ReadTimeout` once its retries are exhausted. NPM, Yarn, Importmap and Gradle rescued that and warn-and-skip; **Bundler (3 call sites), PIP (1) and SPM (2) did not**, so an exhausted-retries timeout escaped `fetch_package`, propagated through `Parallel.map`, and killed the whole scan with an untyped backtrace. SPM was inconsistent even with itself — it warn-and-skipped on a generic non-200 yet died on a timeout.

Every parser that talks to a registry now routes through one helper, and `HttpClient.get` appears in exactly **one** place in `lib/`.

**Key changes:**

- `lib/soup/parsers/base.rb`: new `registry_response(url, label:, outcome:, **)` performing the GET plus the timeout rescue and returning `nil`; `npm_registry_response` now delegates to it
- `lib/soup/parsers/gradle.rb`: the private `safe_get` is deleted and both call sites use the shared helper
- `lib/soup/parsers/bundler.rb`: all three calls in the fallback chain protected
- `lib/soup/parsers/pip.rb`: its single call protected
- `lib/soup/parsers/spm.rb`: both calls protected (with and without `GITHUB_TOKEN`)
- `spec/soup/bundler_parser_spec.rb`, `spec/soup/pip_parser_spec.rb`, `spec/soup/spm_parser_spec.rb`: 8 new examples mirroring the existing npm/yarn timeout specs, as the issue's Testing Details asks. These three parsers previously had **zero** timeout specs

### Design note for reviewers

The rescue implementation is shared by all seven parsers, but the **outcome clause is a parameter**. Gradle's `safe_get` fed a mirror fall-through loop: a timeout on `search.maven.org` frequently still resolves the coordinate from `maven.google.com`, so emitting "package omitted from SOUP" there would be false whenever a later mirror succeeds. Gradle therefore reports `trying the next repository` / `trying the per-repository POM fallbacks`, while every other parser keeps `package omitted from SOUP`.

Bundler's chain needed its own decision: a timeout means rubygems.org is unreachable after every retry, so the remaining fallbacks would time out too. The gem is skipped rather than walking the rest of the chain, and a spec asserts the un-attempted request was never made.

### Verification

Load-bearing confirmed: reverting the three parsers makes the new specs fail with `Net::OpenTimeout: execution expired` escaping — exactly the untyped backtrace the issue describes. A residual branch-coverage dip was traced to Bundler's 2nd and 3rd nil-guards, and specs were added for those too.

Full suite 281 examples, 0 failures (273 before, plus the 8 new); line coverage 98.76% -> 98.77%; branch coverage 89.09% -> 89.47%; RuboCop clean across all 39 files.

Out of scope and untouched, per the issue: the non-200 response policy (CONS-001) and broadening the rescued exception classes (ERR-001).

Closes #381

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
