### PR TITLE
#380: record unresolvable packages instead of skipping or aborting

### DIFF
--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -203,10 +203,26 @@ module SOUP
       cached = @cached_packages[name]
       return unless cached
 
+      restore_unresolved_metadata(package, cached) if package.unresolved
       package.last_verified_at = cached['last_verified_at']
       package.risk_level = cached['risk_level']
       package.requirements = cached['requirements']
       package.verification_reasoning = cached['verification_reasoning']
+    end
+
+    # When this run could not reach the registry, keep whatever a previous run
+    # resolved instead of downgrading the entry to NOASSERTION -- a transient
+    # outage must not blank out metadata already recorded in the register.
+    #
+    # Only restored when the cached entry is for the SAME version: licenses do
+    # change between releases, so carrying an older version's license onto a
+    # newly pinned one would assert something we never verified.
+    def restore_unresolved_metadata(package, cached)
+      return unless cached['version'].to_s == package.version.to_s
+
+      package.license = cached['license'] unless cached['license'].to_s.empty?
+      package.description = cached['description'] unless cached['description'].to_s.empty?
+      package.website = cached['website'] unless cached['website'].to_s.empty?
     end
 
     def apply_dependency_defaults(package)

--- a/lib/soup/package.rb
+++ b/lib/soup/package.rb
@@ -28,6 +28,7 @@ module SOUP
       @requirements = ''
       @verification_reasoning = ''
       @dependency = false
+      @unresolved = false
     end
 
     # Parser-produced fields. Set once during BaseParser#build_package and
@@ -39,6 +40,14 @@ module SOUP
     # Verification fields. Filled in by Application#check_packages from the
     # cache, dependency defaults, or interactive prompts.
     attr_accessor :last_verified_at, :risk_level, :requirements, :verification_reasoning
+
+    # True when the registry lookup failed this run (timeout, 404 for a package
+    # absent from the registry, 403 for a private one) so license/description/
+    # website could not be fetched. The entry still belongs in the register --
+    # the dependency exists either way -- so Application#apply_cached_metadata
+    # restores those three fields from .soup.json when a previous run resolved
+    # them. Deliberately not serialized: it describes this run, not the package.
+    attr_accessor :unresolved
 
     # True when all four verification fields are non-empty (i.e. the package is
     # ready to be rendered into the SOUP markdown). Use this instead of

--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -44,6 +44,33 @@ module SOUP
       package
     end
 
+    # Record a package whose registry lookup failed -- a timeout, a 404 for a
+    # package that is simply not in the public registry, or a 403 for a private
+    # one. A SOUP register must enumerate every component, so a failed lookup is
+    # a metadata gap, not evidence the dependency is absent: dropping the entry
+    # would understate the register, and aborting the run would discard every
+    # other package resolved so far.
+    #
+    # The entry carries everything the lockfile already told us (name, version,
+    # direct/transitive) and marks the license NOASSERTION, which
+    # Application#validate_license reports without failing the build. When a
+    # previous run resolved this package, Application restores the richer
+    # metadata from .soup.json, so a transient outage never blanks the register.
+    def unresolved_package(name:, file:, language:, version:, dependency:)
+      package = build_package(
+        name: name,
+        file: file,
+        language: language,
+        version: version,
+        license: NOASSERTION_LICENSE,
+        description: nil,
+        website: nil,
+        dependency: dependency
+      )
+      package.unresolved = true
+      package
+    end
+
     def normalize_license(license)
       return license if license.nil?
       return license if license.respond_to?(:empty?) && license.empty?
@@ -90,14 +117,14 @@ module SOUP
       versions = payload['versions']
 
       if versions.nil?
-        warn("Skipping #{name}@#{version}: registry response has no versions key; package omitted from SOUP")
+        warn("Skipping #{name}@#{version}: registry response has no versions key; recorded without registry metadata")
         return
       end
 
       package_details = versions[version]
 
       if package_details.nil?
-        warn("Skipping #{name}@#{version}: version not present in registry; package omitted from SOUP")
+        warn("Skipping #{name}@#{version}: version not present in registry; recorded without registry metadata")
         return
       end
 
@@ -130,13 +157,15 @@ module SOUP
     #
     # `label` names what is being skipped: the package for the single-source
     # parsers, the URL itself for gradle's mirror loop. `outcome` states what
-    # happens next, because a timeout omits the package for most parsers but for
-    # gradle only advances to the next repository -- claiming omission there
-    # would be false whenever a later mirror resolves the coordinate.
+    # happens next, because most parsers record the package without registry
+    # metadata while gradle only advances to the next repository -- claiming
+    # either outcome for the other would be false.
     #
-    # Deliberately stops short of the non-200 branch: the parsers disagree on
-    # whether that warns-and-skips or raises, and unifying it is CONS-001.
-    def registry_response(url, label:, outcome: 'package omitted from SOUP', **)
+    # A nil return and a non-200 are handled the same way by every caller: warn,
+    # then record the package via unresolved_package. Only SPM's rate-limit and
+    # bad-credentials responses still abort, because those are global conditions
+    # that would fail every remaining lookup identically.
+    def registry_response(url, label:, outcome: 'recorded without registry metadata', **)
       HttpClient.get(url, **)
     rescue Net::OpenTimeout, Net::ReadTimeout => e
       warn("Skipping #{label}: network timeout after retries (#{e.message}); #{outcome}")

--- a/lib/soup/parsers/bundler.rb
+++ b/lib/soup/parsers/bundler.rb
@@ -23,26 +23,34 @@ module SOUP
 
     def fetch_package(file, direct_deps, spec)
       label = "#{spec.name} #{spec.version}"
+      version = spec.version&.to_s&.strip
+      dependency = !direct_deps.include?(spec.name)
       version_url = "https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{spec.version}.json"
       # A timeout means rubygems.org is unreachable after every retry, so the
-      # remaining fallbacks would time out too -- skip the gem rather than walk
-      # the rest of the chain. CONS-002.
+      # remaining fallbacks would time out too -- record the gem as unresolved
+      # rather than walking the rest of the chain. CONS-002.
       response = registry_response(version_url, label: label)
-      return if response.nil?
+      return unresolved_package(name: spec.name, file: file, language: 'Ruby', version: version, dependency: dependency) if response.nil?
 
       if response.code != 200
         latest_url = "https://api.rubygems.org/api/v1/versions/#{spec.name}/latest.json"
         response = registry_response(latest_url, label: label)
-        return if response.nil?
+        return unresolved_package(name: spec.name, file: file, language: 'Ruby', version: version, dependency: dependency) if response.nil?
 
-        raise(RegistryError, http_error_message(response, url: latest_url, package: label)) unless response.code == 200
+        if response.code != 200
+          warn(http_error_message(response, url: latest_url, package: label))
+          return unresolved_package(name: spec.name, file: file, language: 'Ruby', version: version, dependency: dependency)
+        end
 
         latest_version = JSON.parse(response.body)['version']
         fallback_url = "https://api.rubygems.org/api/v2/rubygems/#{spec.name}/versions/#{latest_version}.json"
         response = registry_response(fallback_url, label: "#{spec.name} #{latest_version}")
-        return if response.nil?
+        return unresolved_package(name: spec.name, file: file, language: 'Ruby', version: version, dependency: dependency) if response.nil?
 
-        raise(RegistryError, http_error_message(response, url: fallback_url, package: "#{spec.name} #{latest_version}")) unless response.code == 200
+        if response.code != 200
+          warn(http_error_message(response, url: fallback_url, package: "#{spec.name} #{latest_version}"))
+          return unresolved_package(name: spec.name, file: file, language: 'Ruby', version: version, dependency: dependency)
+        end
       end
 
       package_details = JSON.parse(response.body)
@@ -51,11 +59,11 @@ module SOUP
         name: spec.name,
         file: file,
         language: 'Ruby',
-        version: spec.version&.to_s&.strip,
+        version: version,
         license: package_details['licenses']&.first&.strip,
         description: Package.sanitize_description(package_details['info'], first_sentence: true),
         website: package_details['homepage_uri']&.strip,
-        dependency: !direct_deps.include?(spec.name)
+        dependency: dependency
       )
     end
   end

--- a/lib/soup/parsers/gradle.rb
+++ b/lib/soup/parsers/gradle.rb
@@ -101,9 +101,11 @@ module SOUP
         end
       end
 
+      coordinate = "#{group_id}:#{artifact_id}"
+
       unless resolved
-        warn(unresolved_message(response, url: last_url, package: "#{group_id}:#{artifact_id} #{version}"))
-        return
+        warn(unresolved_message(response, url: last_url, package: "#{coordinate} #{version}"))
+        return unresolved_package(name: coordinate, file: file, language: 'Kotlin', version: version, dependency: !manifest_mentions?(main_file, coordinate))
       end
 
       build_package(

--- a/lib/soup/parsers/importmap.rb
+++ b/lib/soup/parsers/importmap.rb
@@ -53,17 +53,17 @@ module SOUP
       # No label override: the version is only known after this response, so the
       # timeout warning names the package alone.
       response = npm_registry_response(name: name)
-      return if response.nil?
+      return unresolved_package(name: name, file: file, language: 'JS', version: version, dependency: false) if response.nil?
 
       if response.code != 200
         warn(http_error_message(response, url: npm_registry_url(name), package: name))
-        return
+        return unresolved_package(name: name, file: file, language: 'JS', version: version, dependency: false)
       end
 
       payload = JSON.parse(response.body)
       resolved_version = version || payload.dig('dist-tags', 'latest')
       package_details = lookup_npm_registry_version(payload, name: name, version: resolved_version)
-      return if package_details.nil?
+      return unresolved_package(name: name, file: file, language: 'JS', version: resolved_version, dependency: false) if package_details.nil?
 
       build_npm_registry_package(
         file: file,

--- a/lib/soup/parsers/npm.rb
+++ b/lib/soup/parsers/npm.rb
@@ -28,24 +28,25 @@ module SOUP
       name = key.split('node_modules/').last
       version = value['version']
       label = "#{name}@#{version}"
+      dependency = !direct_deps.include?(name)
 
       response = npm_registry_response(name: name, label: label)
-      return if response.nil?
+      return unresolved_package(name: name, file: file, language: 'JS', version: version, dependency: dependency) if response.nil?
 
       if response.code != 200
         warn(http_error_message(response, url: npm_registry_url(name), package: label))
-        return
+        return unresolved_package(name: name, file: file, language: 'JS', version: version, dependency: dependency)
       end
 
       package_details = lookup_npm_registry_version(JSON.parse(response.body), name: name, version: version)
-      return if package_details.nil?
+      return unresolved_package(name: name, file: file, language: 'JS', version: version, dependency: dependency) if package_details.nil?
 
       build_npm_registry_package(
         file: file,
         name: name,
         version: version,
         package_details: package_details,
-        dependency: !direct_deps.include?(name)
+        dependency: dependency
       )
     end
   end

--- a/lib/soup/parsers/pip.rb
+++ b/lib/soup/parsers/pip.rb
@@ -77,10 +77,14 @@ module SOUP
 
     def fetch_package(file, direct_deps, pip_package, version)
       url = "https://pypi.org/pypi/#{pip_package.sub(/\[[^\]]+\]/, '')}/json"
+      dependency = !direct_deps.include?(normalize_pip_name(pip_package.sub(/\[[^\]]+\]/, '')))
       response = registry_response(url, label: "#{pip_package}==#{version}")
-      return if response.nil?
+      return unresolved_package(name: pip_package, file: file, language: 'Python', version: version, dependency: dependency) if response.nil?
 
-      raise(RegistryError, http_error_message(response, url: url, package: "#{pip_package}==#{version}")) unless response.code == 200
+      if response.code != 200
+        warn(http_error_message(response, url: url, package: "#{pip_package}==#{version}"))
+        return unresolved_package(name: pip_package, file: file, language: 'Python', version: version, dependency: dependency)
+      end
 
       package_details = JSON.parse(response.body)
       info = package_details['info']
@@ -93,7 +97,7 @@ module SOUP
         license: extract_pip_license(info),
         description: Package.sanitize_description(info['summary'], first_sentence: true),
         website: info['home_page']&.strip,
-        dependency: !direct_deps.include?(normalize_pip_name(pip_package.sub(/\[[^\]]+\]/, '')))
+        dependency: dependency
       )
     end
 

--- a/lib/soup/parsers/spm.rb
+++ b/lib/soup/parsers/spm.rb
@@ -101,20 +101,28 @@ module SOUP
           registry_response(url, label: pin_id, headers: { Authorization: "token #{token}" })
         end
 
-      return if response.nil?
+      # The pin identity is all we know when the lookup fails, so it stands in
+      # for the repository name the GitHub payload would otherwise supply.
+      return unresolved_package(name: pin_id, file: file, language: 'Swift', version: version, dependency: !manifest_mentions?(main_file, pin_id)) if response.nil?
 
       unless response.code == 200
+        # Rate limiting and bad credentials are global conditions -- every
+        # remaining lookup would fail the same way -- so they still abort with
+        # actionable guidance rather than filling the register with unresolved
+        # entries.
         combined = github_error_message(response)
         raise(RateLimitError, 'GitHub API: rate limit exceeded. Please set GITHUB_TOKEN to raise the rate limit.') if combined.include?('rate limit')
         raise(AuthenticationError, 'GitHub API: Bad credentials. Please verify GITHUB_TOKEN.') if combined.downcase.include?('bad credentials')
 
         warn(http_error_message(response, url: url, package: pin_id))
-        return
+        return unresolved_package(name: pin_id, file: file, language: 'Swift', version: version, dependency: !manifest_mentions?(main_file, pin_id))
       end
 
       package_details = JSON.parse(response.body)
 
-      return if package_details['private']
+      # A private repository is still a SOUP component, so it is recorded rather
+      # than dropped. The lookup succeeded, so its real metadata is used.
+      warn("#{pin_id} resolves to a private repository; recording it with the metadata GitHub returned") if package_details['private']
 
       build_package(
         name: package_details['name'],

--- a/lib/soup/parsers/yarn.rb
+++ b/lib/soup/parsers/yarn.rb
@@ -43,23 +43,25 @@ module SOUP
       name = js_package[:name]
       version = js_package[:version]
       label = "#{name}@#{version}"
+      dependency = !direct_deps.include?(name)
 
       response = npm_registry_response(name: name, label: label)
-      return if response.nil?
+      return unresolved_package(name: name, file: file, language: 'JS', version: version, dependency: dependency) if response.nil?
 
-      # Unlike the NPM and Importmap parsers, a non-200 here aborts the whole
-      # scan rather than skipping the package. CONS-001 tracks unifying that.
-      raise(RegistryError, http_error_message(response, url: npm_registry_url(name), package: label)) unless response.code == 200
+      if response.code != 200
+        warn(http_error_message(response, url: npm_registry_url(name), package: label))
+        return unresolved_package(name: name, file: file, language: 'JS', version: version, dependency: dependency)
+      end
 
       package_details = lookup_npm_registry_version(JSON.parse(response.body), name: name, version: version)
-      return if package_details.nil?
+      return unresolved_package(name: name, file: file, language: 'JS', version: version, dependency: dependency) if package_details.nil?
 
       build_npm_registry_package(
         file: file,
         name: name,
         version: version,
         package_details: package_details,
-        dependency: !direct_deps.include?(name)
+        dependency: dependency
       )
     end
   end

--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -33,6 +33,43 @@ RSpec.describe(SOUP::Application) do
     %w[--skip_bundler --skip_gradle --skip_npm --skip_pip --skip_spm --skip_yarn]
   end
 
+  def skip_parsers_except_pip
+    %w[--skip_bundler --skip_composer --skip_gradle --skip_npm --skip_spm --skip_yarn]
+  end
+
+  # Point detect_packages at a real requirements.txt whose registry lookup 404s,
+  # so the PIP parser produces an unresolved package entry.
+  def stub_unresolved_pip_package
+    requirements = write_fixture('requirements.txt', "requests==2.31.0\n")
+    allow(Dir).to(receive(:glob).and_return([]))
+    allow(Dir).to(receive(:glob).with("#{Dir.pwd}/**/requirements.txt").and_return([requirements]))
+    stub_request(:get, 'https://pypi.org/pypi/requests/json').to_return(status: 404, body: 'Not Found')
+  end
+
+  def cached_requests_entry(version:)
+    {
+      requests: {
+        language: 'Python',
+        package: 'requests',
+        version: version,
+        license: 'Apache Software License',
+        description: 'HTTP for humans',
+        website: 'https://requests.readthedocs.io',
+        last_verified_at: '2026-01-01',
+        risk_level: 'Low',
+        requirements: 'Cached requirements',
+        verification_reasoning: 'Cached reasoning'
+      }
+    }.to_json
+  end
+
+  # Runs a --soup scan over the stubbed requirements.txt and returns the entry
+  # save_files wrote back to .soup.json.
+  def scan_and_read_cached_requests
+    described_class.new(soup_args(skip: skip_parsers_except_pip)).execute
+    JSON.parse(File.read(cache_file.path))['requests']
+  end
+
   def licenses_args(extra: [], skip: skip_all_parsers)
     ['--licenses', '--licenses_file', licenses_file.path, '--exceptions_file', exceptions_file.path] + extra + skip
   end
@@ -188,6 +225,34 @@ RSpec.describe(SOUP::Application) do
     it 'names a skip option that Options actually defines for every entry' do
       options = SOUP::Options.new(['--licenses', '--licenses_file', licenses_file.path, '--exceptions_file', exceptions_file.path]).parse
       expect(registry.reject { |_file, config| options.respond_to?(config[:skip]) }).to(be_empty)
+    end
+  end
+
+  # CONS-001: a package whose registry lookup fails is still recorded, so the
+  # register enumerates every component. When a previous run resolved it, that
+  # metadata is restored rather than downgraded to NOASSERTION.
+  describe 'unresolved packages' do
+    before { stub_unresolved_pip_package }
+
+    it 'records the package with NOASSERTION when nothing was cached', :aggregate_failures do
+      entry = scan_and_read_cached_requests
+      expect(entry['license']).to(eq('NOASSERTION'))
+      expect(entry['version']).to(eq('2.31.0'))
+    end
+
+    it 'restores license, description and website from a same-version cache entry', :aggregate_failures do
+      File.write(cache_file.path, cached_requests_entry(version: '2.31.0'))
+      entry = scan_and_read_cached_requests
+      expect(entry['license']).to(eq('Apache Software License'))
+      expect(entry['description']).to(eq('HTTP for humans'))
+      expect(entry['website']).to(eq('https://requests.readthedocs.io'))
+    end
+
+    # Licenses change between releases, so an older version's metadata must not
+    # be carried onto a newly pinned one.
+    it 'does not restore metadata cached against a different version' do
+      File.write(cache_file.path, cached_requests_entry(version: '1.0.0'))
+      expect(scan_and_read_cached_requests['license']).to(eq('NOASSERTION'))
     end
   end
 

--- a/spec/soup/bundler_parser_spec.rb
+++ b/spec/soup/bundler_parser_spec.rb
@@ -38,10 +38,11 @@ RSpec.describe(SOUP::BundlerParser) do
 
     before { stub_request(:get, url).to_timeout }
 
-    it 'skips the gem instead of aborting the scan', :aggregate_failures do
+    it 'records the gem as unresolved instead of aborting the scan', :aggregate_failures do
       expect { parser.parse('Gemfile.lock', packages) }
         .not_to(raise_error)
-      expect(packages).to(be_empty)
+      expect(packages['test-gem']).to(have_attributes(version: '1.0.0', language: 'Ruby', license: 'NOASSERTION'))
+      expect(packages['test-gem'].unresolved).to(be(true))
     end
 
     it 'names the gem in the skip warning' do
@@ -95,15 +96,34 @@ RSpec.describe(SOUP::BundlerParser) do
     # its own timeout guard. A timeout means rubygems.org is unreachable after
     # every retry, so the remaining fallbacks would time out too -- the gem is
     # skipped rather than walking the rest of the chain.
+    # CONS-001: the final fallback returning a non-200 used to raise and abort.
+    context 'when the resolved-version fallback returns a non-200' do
+      let(:packages) { {} }
+
+      before do
+        stub_request(:get, 'https://api.rubygems.org/api/v1/versions/test-gem/latest.json')
+          .to_return(status: 200, body: { version: '2.0.0' }.to_json)
+        stub_request(:get, 'https://api.rubygems.org/api/v2/rubygems/test-gem/versions/2.0.0.json')
+          .to_return(status: 404, body: 'Not Found')
+      end
+
+      it 'warns and records the gem as unresolved', :aggregate_failures do
+        expect { parser.parse('Gemfile.lock', packages) }
+          .to(output(/HTTP 404.*test-gem 2\.0\.0/m).to_stderr)
+        expect(packages['test-gem']).to(have_attributes(version: '1.0.0', license: 'NOASSERTION'))
+        expect(packages['test-gem'].unresolved).to(be(true))
+      end
+    end
+
     context 'when the latest-version lookup times out' do
       let(:packages) { {} }
 
       before { stub_request(:get, 'https://api.rubygems.org/api/v1/versions/test-gem/latest.json').to_timeout }
 
-      it 'skips the gem without attempting the remaining fallback', :aggregate_failures do
+      it 'records the gem without attempting the remaining fallback', :aggregate_failures do
         expect { parser.parse('Gemfile.lock', packages) }
           .not_to(raise_error)
-        expect(packages).to(be_empty)
+        expect(packages['test-gem']).to(have_attributes(version: '1.0.0', license: 'NOASSERTION'))
         expect(a_request(:get, %r{api/v2/rubygems/test-gem/versions/2\.0\.0\.json})).not_to(have_been_made)
       end
     end
@@ -117,10 +137,10 @@ RSpec.describe(SOUP::BundlerParser) do
         stub_request(:get, 'https://api.rubygems.org/api/v2/rubygems/test-gem/versions/2.0.0.json').to_timeout
       end
 
-      it 'skips the gem and names the resolved version in the warning', :aggregate_failures do
+      it 'records the gem and names the resolved version in the warning', :aggregate_failures do
         expect { parser.parse('Gemfile.lock', packages) }
           .to(output(/Skipping test-gem 2\.0\.0: network timeout after retries/).to_stderr)
-        expect(packages).to(be_empty)
+        expect(packages['test-gem']).to(have_attributes(version: '1.0.0', license: 'NOASSERTION'))
       end
     end
 
@@ -130,10 +150,14 @@ RSpec.describe(SOUP::BundlerParser) do
           .to_return(status: 500, body: 'Internal Server Error', headers: { Status: 'Internal Server Error' })
       end
 
-      it 'raises a SOUP::RegistryError with status + url + package context' do
+      # CONS-001: this used to raise RegistryError and abort the whole scan.
+      # Every parser now records the gem with what the lockfile already knows.
+      it 'warns with status + url + package context and records the gem', :aggregate_failures do
         packages = {}
         expect { parser.parse('Gemfile.lock', packages) }
-          .to(raise_error(SOUP::RegistryError, /HTTP 500.*test-gem.*api\.rubygems\.org/m))
+          .to(output(/HTTP 500.*test-gem.*api\.rubygems\.org/m).to_stderr)
+        expect(packages['test-gem']).to(have_attributes(version: '1.0.0', license: 'NOASSERTION'))
+        expect(packages['test-gem'].unresolved).to(be(true))
       end
     end
   end

--- a/spec/soup/gradle_parser_spec.rb
+++ b/spec/soup/gradle_parser_spec.rb
@@ -176,11 +176,12 @@ RSpec.describe(SOUP::GradleParser) do
         stub_request(:get, /oss\.sonatype\.org/).to_return(status: 503, body: 'sonatype offline')
       end
 
-      it 'warns with http_error_message (status, url, package, truncated body)', :aggregate_failures do
+      it 'warns with http_error_message and records the coordinate', :aggregate_failures do
         packages = {}
         expect { parser.parse(lockfile_path, packages) }
           .to(output(/HTTP 503.*com\.example:library 1\.0\.0.*\.pom.*offline/m).to_stderr)
-        expect(packages).to(be_empty)
+        expect(packages['com.example:library']).to(have_attributes(version: '1.0.0', language: 'Kotlin', license: 'NOASSERTION'))
+        expect(packages['com.example:library'].unresolved).to(be(true))
       end
     end
   end
@@ -229,11 +230,12 @@ RSpec.describe(SOUP::GradleParser) do
         stub_request(:get, /oss\.sonatype\.org/).to_timeout
       end
 
-      it 'warns and skips the package without raising', :aggregate_failures do
+      it 'warns and records the coordinate without raising', :aggregate_failures do
         packages = {}
         expect { parser.parse(lockfile_path, packages) }
           .to(output(/all Maven lookups timed out/).to_stderr)
-        expect(packages).to(be_empty)
+        expect(packages['com.example:library']).to(have_attributes(version: '1.0.0', license: 'NOASSERTION'))
+        expect(packages['com.example:library'].unresolved).to(be(true))
       end
     end
   end

--- a/spec/soup/importmap_parser_spec.rb
+++ b/spec/soup/importmap_parser_spec.rb
@@ -79,8 +79,9 @@ RSpec.describe(SOUP::ImportmapParser) do
 
     before { stub_request(:get, 'https://registry.npmjs.org/marked').to_return(status: 404, body: 'Not Found') }
 
-    it 'skips the package' do
-      expect(packages).to(be_empty)
+    it 'records the package as unresolved rather than dropping it', :aggregate_failures do
+      expect(packages['marked']).to(have_attributes(version: '12.0.0', language: 'JS', license: 'NOASSERTION'))
+      expect(packages['marked'].unresolved).to(be(true))
     end
   end
 
@@ -133,10 +134,11 @@ RSpec.describe(SOUP::ImportmapParser) do
 
     before { stub_request(:get, 'https://registry.npmjs.org/marked').to_timeout }
 
-    it 'skips the package and names it without a version in the warning', :aggregate_failures do
+    it 'records the package and names it without a version in the warning', :aggregate_failures do
       expect { packages }
         .to(output(/Skipping marked: network timeout after retries/).to_stderr)
-      expect(packages).to(be_empty)
+      expect(packages['marked']).to(have_attributes(version: '12.0.0', license: 'NOASSERTION'))
+      expect(packages['marked'].unresolved).to(be(true))
     end
   end
 
@@ -145,10 +147,11 @@ RSpec.describe(SOUP::ImportmapParser) do
 
     before { stub_request(:get, 'https://registry.npmjs.org/marked').to_return(status: 200, body: registry_body('12.0.0')) }
 
-    it 'warns and omits the package', :aggregate_failures do
+    it 'warns and records the package as unresolved', :aggregate_failures do
       expect { packages }
         .to(output(/version not present/).to_stderr)
-      expect(packages).to(be_empty)
+      expect(packages['marked']).to(have_attributes(version: '99.0.0', license: 'NOASSERTION'))
+      expect(packages['marked'].unresolved).to(be(true))
     end
   end
 end

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -68,10 +68,11 @@ RSpec.describe(SOUP::NPMParser) do
         .to_return(status: 404, body: 'Not Found')
     end
 
-    it 'skips on non-200 response' do
+    it 'records the package as unresolved rather than dropping it', :aggregate_failures do
       packages = {}
       parser.parse(lockfile_path, packages)
-      expect(packages).to(be_empty)
+      expect(packages['lodash']).to(have_attributes(version: '4.17.21', language: 'JS', license: 'NOASSERTION'))
+      expect(packages['lodash'].unresolved).to(be(true))
     end
   end
 
@@ -89,9 +90,9 @@ RSpec.describe(SOUP::NPMParser) do
         .to(output(/Aborting after \d+ retries/).to_stderr)
     end
 
-    it 'retries max_retries+1 times before skipping the package', :aggregate_failures do
+    it 'retries max_retries+1 times before recording the package as unresolved', :aggregate_failures do
       parser.parse(lockfile_path, packages)
-      expect(packages).to(be_empty)
+      expect(packages['lodash']).to(have_attributes(version: '4.17.21', license: 'NOASSERTION'))
       expect(a_request(:get, url)).to(have_been_made.times(SOUP::HttpClient.max_retries + 1))
     end
 
@@ -136,10 +137,11 @@ RSpec.describe(SOUP::NPMParser) do
         .to_return(status: 200, body: { versions: {} }.to_json)
     end
 
-    it 'handles version not found in registry' do
+    it 'records the package as unresolved when its version is absent', :aggregate_failures do
       packages = {}
       parser.parse(lockfile_path, packages)
-      expect(packages).to(be_empty)
+      expect(packages['lodash']).to(have_attributes(version: '4.17.21', license: 'NOASSERTION'))
+      expect(packages['lodash'].unresolved).to(be(true))
     end
   end
 
@@ -149,11 +151,12 @@ RSpec.describe(SOUP::NPMParser) do
         .to_return(status: 200, body: { _id: 'lodash', name: 'lodash', time: {} }.to_json)
     end
 
-    it 'handles unpublished or stub-only packages without raising', :aggregate_failures do
+    it 'records unpublished or stub-only packages without raising', :aggregate_failures do
       packages = {}
       expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
-      expect(packages).to(be_empty)
+      expect(packages['lodash']).to(have_attributes(license: 'NOASSERTION'))
+      expect(packages['lodash'].unresolved).to(be(true))
     end
   end
 

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -121,6 +121,22 @@ RSpec.describe(SOUP::PIPParser) do
     end
   end
 
+  # CONS-001: a 404 usually means the package is private or simply absent from
+  # PyPI. It is still a dependency, so it is recorded rather than dropped.
+  context 'when the registry returns a non-200' do
+    let(:requirements_content) { "requests==2.31.0\n" }
+    let(:packages) { {} }
+
+    before { stub_request(:get, 'https://pypi.org/pypi/requests/json').to_return(status: 404, body: 'Not Found') }
+
+    it 'warns and records the package as unresolved', :aggregate_failures do
+      expect { parser.parse(requirements_path, packages) }
+        .to(output(/HTTP 404.*requests==2\.31\.0/m).to_stderr)
+      expect(packages['requests']).to(have_attributes(version: '2.31.0', language: 'Python', license: 'NOASSERTION'))
+      expect(packages['requests'].unresolved).to(be(true))
+    end
+  end
+
   # CONS-002: HttpClient re-raises Net::ReadTimeout once its retries are
   # exhausted. Before the fix that escaped fetch_package, propagated through
   # Parallel.map, and killed the whole scan with an untyped backtrace. It must
@@ -131,10 +147,11 @@ RSpec.describe(SOUP::PIPParser) do
 
     before { stub_request(:get, 'https://pypi.org/pypi/requests/json').to_timeout }
 
-    it 'skips the package instead of aborting the scan', :aggregate_failures do
+    it 'records the package as unresolved instead of aborting the scan', :aggregate_failures do
       expect { parser.parse(requirements_path, packages) }
         .not_to(raise_error)
-      expect(packages).to(be_empty)
+      expect(packages['requests']).to(have_attributes(version: '2.31.0', language: 'Python', license: 'NOASSERTION'))
+      expect(packages['requests'].unresolved).to(be(true))
     end
 
     it 'names the package as name==version in the skip warning' do

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -57,10 +57,11 @@ RSpec.describe(SOUP::SPMParser) do
 
     before { stub_request(:get, 'https://api.github.com/repos/Alamofire/Alamofire').to_timeout }
 
-    it 'skips the pin instead of aborting the scan', :aggregate_failures do
+    it 'records the pin as unresolved instead of aborting the scan', :aggregate_failures do
       expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
-      expect(packages).to(be_empty)
+      expect(packages['alamofire']).to(have_attributes(version: '5.9.0', language: 'Swift', license: 'NOASSERTION'))
+      expect(packages['alamofire'].unresolved).to(be(true))
     end
 
     it 'names the pin in the skip warning' do
@@ -165,10 +166,15 @@ RSpec.describe(SOUP::SPMParser) do
         .to_return(status: 200, body: private_response)
     end
 
-    it 'skips private repositories' do
+    # CONS-001: a private repository is still a SOUP component. The lookup
+    # succeeded, so it is recorded with the real metadata rather than dropped --
+    # and it is NOT marked unresolved, because nothing failed.
+    it 'records private repositories with the metadata GitHub returned', :aggregate_failures do
       packages = {}
-      parser.parse(lockfile_path, packages)
-      expect(packages).to(be_empty)
+      expect { parser.parse(lockfile_path, packages) }
+        .to(output(/private repository/).to_stderr)
+      expect(packages).not_to(be_empty)
+      expect(packages.values.first.unresolved).to(be(false))
     end
   end
 
@@ -205,10 +211,11 @@ RSpec.describe(SOUP::SPMParser) do
         .to_return(status: [404, 'Not Found'], body: '{}')
     end
 
-    it 'skips non-200 responses' do
+    it 'records the pin as unresolved on a non-200 response', :aggregate_failures do
       packages = {}
       parser.parse(lockfile_path, packages)
-      expect(packages).to(be_empty)
+      expect(packages['alamofire']).to(have_attributes(language: 'Swift', license: 'NOASSERTION'))
+      expect(packages['alamofire'].unresolved).to(be(true))
     end
   end
 
@@ -370,11 +377,12 @@ RSpec.describe(SOUP::SPMParser) do
         .to_return(status: [502, 'Bad Gateway'], body: '<html>upstream timeout</html>')
     end
 
-    it 'warns with status + url + package context and omits the package', :aggregate_failures do
+    it 'warns with status + url + package context and records the pin', :aggregate_failures do
       packages = {}
       expect { parser.parse(lockfile_path, packages) }
         .to(output(%r{HTTP 502 .*package=alamofire.*url=https://api\.github\.com/repos/Alamofire/Alamofire.*body=<html>upstream timeout</html>}m).to_stderr)
-      expect(packages).to(be_empty)
+      expect(packages['alamofire']).to(have_attributes(license: 'NOASSERTION'))
+      expect(packages['alamofire'].unresolved).to(be(true))
     end
   end
 

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -84,12 +84,21 @@ RSpec.describe(SOUP::YarnParser) do
     end
   end
 
-  it 'raises a SOUP::RegistryError on non-200 response' do
-    stub_request(:get, 'https://registry.npmjs.org/lodash')
-      .to_return(status: 500, body: 'Server Error')
-    packages = {}
-    expect { parser.parse(lockfile_path, packages) }
-      .to(raise_error(SOUP::RegistryError, /HTTP 500.*lodash.*registry\.npmjs\.org/m))
+  # CONS-001: a non-200 used to raise RegistryError here and abort the entire
+  # scan, while the NPM parser hitting the identical endpoint merely skipped the
+  # package. All seven parsers now record the package with what the lockfile
+  # knows, so one flaky 5xx can no longer destroy a whole yarn scan.
+  context 'with a non-200 response' do
+    let(:packages) { {} }
+
+    before { stub_request(:get, 'https://registry.npmjs.org/lodash').to_return(status: 500, body: 'Server Error') }
+
+    it 'records the package as unresolved instead of aborting the scan', :aggregate_failures do
+      expect { parser.parse(lockfile_path, packages) }
+        .to(output(/HTTP 500.*lodash.*registry\.npmjs\.org/m).to_stderr)
+      expect(packages['lodash']).to(have_attributes(version: '4.17.21', language: 'JS', license: 'NOASSERTION'))
+      expect(packages['lodash'].unresolved).to(be(true))
+    end
   end
 
   # TEST-305: assert the full retry loop ran and the user saw the
@@ -106,9 +115,9 @@ RSpec.describe(SOUP::YarnParser) do
         .to(output(/Aborting after \d+ retries/).to_stderr)
     end
 
-    it 'retries max_retries+1 times before skipping the package', :aggregate_failures do
+    it 'retries max_retries+1 times before recording the package as unresolved', :aggregate_failures do
       parser.parse(lockfile_path, packages)
-      expect(packages).to(be_empty)
+      expect(packages['lodash']).to(have_attributes(version: '4.17.21', license: 'NOASSERTION'))
       expect(a_request(:get, url)).to(have_been_made.times(SOUP::HttpClient.max_retries + 1))
     end
 
@@ -135,11 +144,12 @@ RSpec.describe(SOUP::YarnParser) do
         .to_return(status: 200, body: missing_version_response)
     end
 
-    it 'skips the package instead of crashing on nil license access', :aggregate_failures do
+    it 'records the package as unresolved instead of crashing on nil license access', :aggregate_failures do
       packages = {}
       expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
-      expect(packages).to(be_empty)
+      expect(packages['lodash']).to(have_attributes(version: '4.17.21', license: 'NOASSERTION'))
+      expect(packages['lodash'].unresolved).to(be(true))
     end
   end
 
@@ -149,11 +159,12 @@ RSpec.describe(SOUP::YarnParser) do
         .to_return(status: 200, body: { _id: 'lodash', name: 'lodash' }.to_json)
     end
 
-    it 'skips the package instead of raising', :aggregate_failures do
+    it 'records the package as unresolved instead of raising', :aggregate_failures do
       packages = {}
       expect { parser.parse(lockfile_path, packages) }
         .not_to(raise_error)
-      expect(packages).to(be_empty)
+      expect(packages['lodash']).to(have_attributes(license: 'NOASSERTION'))
+      expect(packages['lodash'].unresolved).to(be(true))
     end
   end
 


### PR DESCRIPTION
## Summary

Two divergent non-200 styles existed even for the identical `registry.npmjs.org` endpoint: NPM warned and skipped, Yarn raised `RegistryError`. Repo-wide the split was 4 warn+skip (npm, importmap, gradle, spm) versus 3 raise (yarn, bundler, pip) — so the same unresolvable package aborted the entire scan when it came from `yarn.lock` / `Gemfile.lock` / `requirements.txt`, but was silently omitted when it came from `package-lock.json` / importmap / gradle / SPM.

**Neither existing style was kept.** A package may be private, or simply absent from the public registry — it still exists as a dependency and belongs in an IEC 62304 SOUP register. A failed lookup is a **metadata gap, not evidence the dependency is absent**: skipping understates the register, and aborting discards every package resolved so far. Every parser now *records* the package with what the lockfile already knows and marks the licence `NOASSERTION`.

The resulting rule is uniform: **always record the package; restore its cached metadata when a previous run resolved it, otherwise `NOASSERTION`.** A package that resolved as MIT last run and times out today keeps MIT; one never resolved gets `NOASSERTION`.

**Key changes:**

- `lib/soup/parsers/base.rb`: new `unresolved_package(name:, file:, language:, version:, dependency:)` helper, called by all seven parsers
- `lib/soup/parsers/npm.rb`, `yarn.rb`, `importmap.rb`, `pip.rb`, `bundler.rb`, `gradle.rb`, `spm.rb`: every failure path — timeout, non-200, and "version not present in registry" — now records instead of skipping or raising
- `lib/soup/package.rb`: new `unresolved` attribute, deliberately **not** serialized (it describes this run, not the package), so the `.soup.json` schema is unchanged
- `lib/soup/application.rb`: `restore_unresolved_metadata` restores licence/description/website from `.soup.json` for unresolved packages, but only when the cached entry is for the **same version** — licences change between releases, so carrying an older version's licence onto a newly pinned one would assert something never verified
- 8 spec files: 22 existing examples asserted the old "package disappears" contract and were rewritten to assert the new one across all seven parsers, per the issue's Testing Details

### Two deliberate exceptions

- **SPM keeps two raises.** `RateLimitError` and `AuthenticationError` are *global* conditions — every remaining lookup fails identically — so they still abort with actionable guidance rather than filling the register with hundreds of unresolved entries.
- **SPM private repositories are now recorded** with their real metadata instead of being dropped. A private repo is still a SOUP component. They are *not* marked unresolved, because nothing failed.

Warnings that had become false were corrected: `package omitted from SOUP` now reads `recorded without registry metadata`.

### Verified end to end, not only in specs

A real scan against a package absent from PyPI writes it into the register:

```json
"some-private-internal-pkg": {
  "language": "Python", "version": "1.0.0", "license": "NOASSERTION", ...
}
```

with `HTTP 404 ... package=some-private-internal-pkg==1.0.0` on stderr and the run completing normally.

The compliance gate is **not** weakened: an unresolvable package warns but exits 0, while a package whose licence genuinely violates the allowlist still exits 1 — `NOASSERTION` already had that carve-out in `validate_license`.

Full suite 286 examples, 0 failures; line coverage 98.77% -> 98.81%; branch coverage 89.47% -> 89.49%; RuboCop clean across all 39 files. Tests were added for the three genuinely uncovered new paths, including the cache-restore behaviour end to end (same-version restore, and no restore on a version mismatch).

Out of scope and untouched, per the issue: the timeout-rescue divergence was CONS-002, already fixed in #381.

Closes #380

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
