### PR TITLE
#379: remove the unused activesupport dependency

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -1,16 +1,4 @@
 {
-  "activesupport": {
-    "language": "Ruby",
-    "package": "activesupport",
-    "version": "8.1.3",
-    "license": "MIT",
-    "description": "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework",
-    "website": "https://rubyonrails.org",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
   "addressable": {
     "language": "Ruby",
     "package": "addressable",
@@ -35,18 +23,6 @@
     "requirements": "Dependency",
     "verification_reasoning": "Dependency"
   },
-  "base64": {
-    "language": "Ruby",
-    "package": "base64",
-    "version": "0.3.0",
-    "license": "Ruby",
-    "description": "Support for encoding and decoding binary data using a Base64 representation.",
-    "website": "https://github.com/ruby/base64",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
   "bigdecimal": {
     "language": "Ruby",
     "package": "bigdecimal",
@@ -54,30 +30,6 @@
     "license": "Ruby",
     "description": "This library provides arbitrary-precision decimal floating-point number class.",
     "website": "https://github.com/ruby/bigdecimal",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
-  "concurrent-ruby": {
-    "language": "Ruby",
-    "package": "concurrent-ruby",
-    "version": "1.3.8",
-    "license": "MIT",
-    "description": "Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more.",
-    "website": "http://www.concurrent-ruby.com",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
-  "connection_pool": {
-    "language": "Ruby",
-    "package": "connection_pool",
-    "version": "3.0.2",
-    "license": "MIT",
-    "description": "Generic connection pool for Ruby",
-    "website": "https://github.com/mperham/connection_pool",
     "last_verified_at": "2026-05-22",
     "risk_level": "Low",
     "requirements": "Dependency",
@@ -119,18 +71,6 @@
     "requirements": "Dependency",
     "verification_reasoning": "Dependency"
   },
-  "drb": {
-    "language": "Ruby",
-    "package": "drb",
-    "version": "2.2.3",
-    "license": "Ruby",
-    "description": "Distributed object system for Ruby",
-    "website": "https://github.com/ruby/drb",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
   "hashdiff": {
     "language": "Ruby",
     "package": "hashdiff",
@@ -154,18 +94,6 @@
     "risk_level": "Medium",
     "requirements": "Makes http fun! Also, makes consuming restful web services dead easy.",
     "verification_reasoning": "Very popular on rubygems.org"
-  },
-  "i18n": {
-    "language": "Ruby",
-    "package": "i18n",
-    "version": "1.15.2",
-    "license": "MIT",
-    "description": "New wave Internationalization support for Ruby.",
-    "website": "https://github.com/ruby-i18n/i18n",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
   },
   "json": {
     "language": "Ruby",
@@ -203,18 +131,6 @@
     "requirements": "Dependency",
     "verification_reasoning": "Dependency"
   },
-  "logger": {
-    "language": "Ruby",
-    "package": "logger",
-    "version": "1.7.0",
-    "license": "Ruby",
-    "description": "Provides a simple logging utility for outputting messages.",
-    "website": "https://github.com/ruby/logger",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
   "mini_mime": {
     "language": "Ruby",
     "package": "mini_mime",
@@ -222,18 +138,6 @@
     "license": "MIT",
     "description": "A minimal mime type library",
     "website": "https://github.com/discourse/mini_mime",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
-  "minitest": {
-    "language": "Ruby",
-    "package": "minitest",
-    "version": "6.0.6",
-    "license": "MIT",
-    "description": "minitest provides a complete suite of testing facilities supporting",
-    "website": "https://minite.st/",
     "last_verified_at": "2026-05-22",
     "risk_level": "Low",
     "requirements": "Dependency",
@@ -551,18 +455,6 @@
     "requirements": "Dependency",
     "verification_reasoning": "Dependency"
   },
-  "securerandom": {
-    "language": "Ruby",
-    "package": "securerandom",
-    "version": "0.4.1",
-    "license": "Ruby",
-    "description": "Interface for secure random number generator.",
-    "website": "https://github.com/ruby/securerandom",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
   "simplecov": {
     "language": "Ruby",
     "package": "simplecov",
@@ -635,18 +527,6 @@
     "requirements": "Dependency",
     "verification_reasoning": "Dependency"
   },
-  "tzinfo": {
-    "language": "Ruby",
-    "package": "tzinfo",
-    "version": "2.0.6",
-    "license": "MIT",
-    "description": "TZInfo provides access to time zone data and allows times to be converted using time zone rules.",
-    "website": "https://tzinfo.github.io",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
   "unicode-display_width": {
     "language": "Ruby",
     "package": "unicode-display_width",
@@ -666,18 +546,6 @@
     "license": "MIT",
     "description": "[Emoji 17.0] Provides Unicode Emoji data and regexes, incorporating the latest Unicode and Emoji standards",
     "website": "https://github.com/janlelis/unicode-emoji",
-    "last_verified_at": "2026-05-22",
-    "risk_level": "Low",
-    "requirements": "Dependency",
-    "verification_reasoning": "Dependency"
-  },
-  "uri": {
-    "language": "Ruby",
-    "package": "uri",
-    "version": "1.1.1",
-    "license": "Ruby",
-    "description": "URI is a module providing classes to handle Uniform Resource Identifiers",
-    "website": "https://github.com/ruby/uri",
     "last_verified_at": "2026-05-22",
     "risk_level": "Low",
     "requirements": "Dependency",

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'activesupport', '>= 7.1.0'
 gem 'bundler', '>= 2.3.0'
-# gem 'cocoapods', '>= 1.14.0' # Disabled: requires activesupport < 8
+# gem 'cocoapods', '>= 1.14.0' # Not implemented; its activesupport < 8 pin no longer conflicts
 gem 'httparty', '>= 0.20.0'
 gem 'json', '>= 2.6.0'
 gem 'nokogiri', '>= 1.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,47 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.3)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
-    base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
     csv (3.3.6)
     diff-lcs (1.6.2)
-    drb (2.2.3)
     hashdiff (1.2.1)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.15.2)
-      concurrent-ruby (~> 1.0)
     json (2.21.1)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
-    logger (1.7.0)
     mini_mime (1.1.5)
-    minitest (6.0.6)
-      drb (~> 2.0)
-      prism (~> 1.5)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     nokogiri (1.19.4-aarch64-linux-gnu)
@@ -115,7 +92,6 @@ GEM
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
-    securerandom (0.4.1)
     simplecov (1.0.3)
     tty-color (0.6.0)
     tty-cursor (0.7.1)
@@ -127,12 +103,9 @@ GEM
       tty-screen (~> 0.8)
       wisper (~> 2.0)
     tty-screen (0.8.2)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    uri (1.1.1)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -147,7 +120,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activesupport (>= 7.1.0)
   bundler (>= 2.3.0)
   httparty (>= 0.20.0)
   json (>= 2.6.0)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following package managers are supported:
 * SPM (Package.resolved)
 * Yarn (yarn.lock)
 
-Note: CocoaPods (`Podfile.lock`) support was removed pending upstream compatibility. The `cocoapods-core` gem requires `activesupport < 8`, which is incompatible with the ActiveSupport version this project depends on. `Podfile.lock` files are currently skipped silently; support will be reinstated once `cocoapods-core` upgrades.
+Note: CocoaPods (`Podfile.lock`) support is not currently implemented, so `Podfile.lock` files are skipped silently. It was originally removed because `cocoapods-core` requires `activesupport < 8` while this project declared `activesupport >= 7.1.0`. That unused declaration has since been dropped, so the version conflict no longer applies; reinstating CocoaPods support is tracked separately.
 
 For Rails projects using importmap-rails, each `pin '<name>', to: '<https…>'` in `config/importmap.rb` is treated as a
 third-party JavaScript SOUP entry; its npm package and version are derived from the CDN URL and looked up on the npm

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -2,26 +2,18 @@
 
 | **Language** | **Package** | **Version** | **License** | **Description** | **Website** | **Last Verified** | **Risk Level** | **Requirements** | **Verification Reasoning** |
 | :---: | :--- | :---: | :---: | :--- | :--- | :---: | :---: | :--- | :--- |
-| Ruby | activesupport | 8.1.3 | MIT | A toolkit of support libraries and Ruby core extensions extracted from the Rails framework | <https://rubyonrails.org> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | addressable | 2.9.0 | Apache-2.0 | Addressable is an alternative implementation to the URI implementation that is | <https://github.com/sporkmonger/addressable> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | ast | 2.4.3 | MIT | A library for working with Abstract Syntax Trees. | <https://whitequark.github.io/ast/> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | base64 | 0.3.0 | Ruby | Support for encoding and decoding binary data using a Base64 representation. | <https://github.com/ruby/base64> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | bigdecimal | 4.1.2 | Ruby | This library provides arbitrary-precision decimal floating-point number class. | <https://github.com/ruby/bigdecimal> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | concurrent-ruby | 1.3.8 | MIT | Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. | <http://www.concurrent-ruby.com> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | connection_pool | 3.0.2 | MIT | Generic connection pool for Ruby | <https://github.com/mperham/connection_pool> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | crack | 1.0.1 | MIT | Really simple JSON and XML parsing, ripped from Merb and Rails. | <https://github.com/jnunemaker/crack> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | csv | 3.3.6 | Ruby | The CSV library provides a complete interface to CSV files and data | <https://github.com/ruby/csv> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | diff-lcs | 1.6.2 | MIT | Diff::LCS computes the difference between two Enumerable sequences using the | <https://github.com/halostatue/diff-lcs> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | drb | 2.2.3 | Ruby | Distributed object system for Ruby | <https://github.com/ruby/drb> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | hashdiff | 1.2.1 | MIT | Hashdiff is a diff lib to compute the smallest difference between two hashes | <https://github.com/liufengyun/hashdiff> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | httparty | 0.24.2 | MIT | Makes http fun! Also, makes consuming restful web services dead easy. | <https://github.com/jnunemaker/httparty> | 2026-05-22 | Medium | Makes http fun! Also, makes consuming restful web services dead easy. | Very popular on rubygems.org |
-| Ruby | i18n | 1.15.2 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | json | 2.21.1 | Ruby | A JSON implementation as a JRuby extension. | <https://github.com/ruby/json> | 2026-05-22 | Low | Used to read package manager and cache files. | Very popular on rubygems.org |
 | Ruby | language_server-protocol | 3.17.0.6 | MIT | A Language Server Protocol SDK | <https://github.com/mtsmfm/language_server-protocol-ruby> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | lint_roller | 1.1.0 | MIT | A plugin specification for linter and formatter rulesets | <https://github.com/standardrb/lint_roller> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | logger | 1.7.0 | Ruby | Provides a simple logging utility for outputting messages. | <https://github.com/ruby/logger> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | mini_mime | 1.1.5 | MIT | A minimal mime type library | <https://github.com/discourse/mini_mime> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | minitest | 6.0.6 | MIT | minitest provides a complete suite of testing facilities supporting | <https://minite.st/> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | multi_xml | 0.9.1 | MIT | Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML. | <https://github.com/sferik/multi_xml> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | nokogiri | 1.19.4 | MIT | Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby | <https://nokogiri.org> | 2026-05-22 | Low | XML parser | Most popular library |
 | Ruby | optparse | 0.8.1 | Ruby | OptionParser is a class for command-line option analysis | <https://github.com/ruby/optparse> | 2026-05-22 | Low | Used to parse command line arguments. | Very popular on rubygems.org |
@@ -48,17 +40,14 @@
 | Ruby | rubocop-rspec | 3.10.2 | MIT | Code style checking for RSpec files. | <https://github.com/rubocop/rubocop-rspec> | 2026-05-22 | Low | Code style checking for RSpec files. A plugin for the RuboCop code style enforcing & linting tool | Most popular gem |
 | Ruby | rubocop-thread_safety | 0.7.3 | MIT | Thread-safety checks via static analysis. | <https://github.com/rubocop/rubocop-thread_safety> | 2026-05-22 | Low | Ruby linter | Most popular gem |
 | Ruby | ruby-progressbar | 1.13.0 | MIT | Ruby/ProgressBar is an extremely flexible text progress bar library for Ruby | <https://github.com/jfelchner/ruby-progressbar> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | securerandom | 0.4.1 | Ruby | Interface for secure random number generator. | <https://github.com/ruby/securerandom> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | simplecov | 1.0.3 | MIT | Code coverage for Ruby with a powerful configuration library and automatic merging of coverage across test suites | <https://github.com/simplecov-ruby/simplecov> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | tty-color | 0.6.0 | MIT | Terminal color capabilities detection | <https://ttytoolkit.org> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | tty-cursor | 0.7.1 | MIT | The purpose of this library is to help move the terminal cursor around and manipulate text by using intuitive method calls. | <https://ttytoolkit.org> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | tty-prompt | 0.23.1 | MIT | A beautiful and powerful interactive command line prompt with a robust API for getting and validating complex inputs. | <https://ttytoolkit.org> | 2026-05-22 | Low | Prompt for TTY | Most popular on RubyGem |
 | Ruby | tty-reader | 0.9.0 | MIT | A set of methods for processing keyboard input in character, line and multiline modes | <https://ttytoolkit.org> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | tty-screen | 0.8.2 | MIT | Terminal screen size detection that works on Linux, macOS and Windows systems and supports Ruby MRI, JRuby, TruffleRuby and Rubinius interpreters. | <https://ttytoolkit.org> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | tzinfo | 2.0.6 | MIT | TZInfo provides access to time zone data and allows times to be converted using time zone rules. | <https://tzinfo.github.io> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | unicode-display_width | 3.2.0 | MIT | [Unicode 17.0.0] Determines the monospace display width of a string using EastAsianWidth.txt, Unicode general category, Emoji specification, and other data. | <https://github.com/janlelis/unicode-display_width> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | unicode-emoji | 4.2.0 | MIT | [Emoji 17.0] Provides Unicode Emoji data and regexes, incorporating the latest Unicode and Emoji standards | <https://github.com/janlelis/unicode-emoji> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | uri | 1.1.1 | Ruby | URI is a module providing classes to handle Uniform Resource Identifiers | <https://github.com/ruby/uri> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | webmock | 3.26.2 | MIT | WebMock allows stubbing HTTP requests and setting expectations on HTTP requests. | <https://github.com/bblimke/webmock> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | wisper | 2.0.1 | MIT | A micro library providing objects with Publish-Subscribe capabilities. | <https://github.com/krisleech/wisper> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | yarn_lock_parser | 0.1.0 | MIT | Parser for yarn.lock files. | <https://rubygems.org/yarn_lock_parser> | 2026-05-22 | Low | Read yarn lock file | Popular gem |


### PR DESCRIPTION
## Summary

`activesupport (>= 7.1.0, locked 8.1.3)` was declared as a direct runtime dependency but was never used — a leftover from the removed CocoaPods integration. Verified exhaustively before removing it:

- no `Bundler.require` anywhere (`bin/soup.rb` requires only `lib/soup/application`)
- no `require 'active_support'` in `lib/`, `bin/` or `spec/`
- no gem in `Gemfile.lock` depends on it — it was purely the direct declaration
- at runtime `defined?(ActiveSupport)` was `nil` and `String#first` (an ActiveSupport-only method) did not exist, so **the gem was never even loaded**

**Key changes:**

- `Gemfile`: removed `gem 'activesupport', '>= 7.1.0'`
- `Gemfile.lock`: 11 gems dropped — activesupport, base64, concurrent-ruby, connection_pool, drb, i18n, logger, minitest, securerandom, tzinfo, uri — matching the issue's estimate and shrinking the tool's own IEC 62304 SOUP register
- `.soup.json` and `docs/soup.md`: regenerated by actually running `bin/soup.rb` after the removal, which is itself end-to-end proof the tool works without the gem. The register goes from **60 to 49 packages**, and both files are **pure deletions** — zero added or modified lines — so no retained package lost its risk level, requirements or verification reasoning
- `README.md`: the CocoaPods note claimed `cocoapods-core`'s `activesupport < 8` pin is "incompatible with the ActiveSupport version this project depends on". After this change the project depends on **no** ActiveSupport version, so that sentence became false — the issue's own Technical Details flags exactly this. Rewritten to state the version conflict no longer applies, with the parallel `Gemfile` comment updated to match

CocoaPods is **not** reinstated; that remains out of scope per #248.

Deliberately left unchanged: `lib/soup/application.rb:36` and `spec/soup/options_spec.rb:25` state that `cocoapods-core` **is pinned to** `activesupport < 8`, which is still true of `cocoapods-core` itself. The historical `String#first` comments in `composer.rb` and its spec are likewise accurate history.

### Test gate — explicit no-test exception

No unit tests were added because **not one line of `lib/` or `spec/` changed**. This falls squarely in the stated exception categories: dependency config (`Gemfile`, `Gemfile.lock`), docs (`README.md`) and generated files (`.soup.json`, `docs/soup.md`). There is no new logic to unit-test; the substantive evidence is the full suite passing unchanged plus the successful live run of the binary.

Verification: full suite 286 examples, 0 failures; line coverage 98.81% and branch coverage 89.49%, both unchanged since no code was touched; RuboCop clean across all 39 files; markdownlint-cli2 with the repo's config reports 0 issues.

Closes #379

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: No `lib/` or `spec/` code changed — this is dependency config, docs and generated files, which have no unit-testable logic. The full suite passes unchanged and the binary was run end to end.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
