### PR TITLE
#378: validate the cache file before detection can populate state

### DIFF
--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -67,12 +67,33 @@ module SOUP
       [@options.licenses_file, @options.exceptions_file].each do |file|
         raise(ConfigurationError, "Configuration file not found: #{file}") unless File.exist?(file)
 
-        begin
-          JSON.parse(File.read(file))
-        rescue JSON::ParserError => e
-          raise(ConfigurationError, "Invalid JSON in configuration file #{file}: #{e.message}")
-        end
+        validate_json!(file)
       end
+
+      validate_cache_file!
+    end
+
+    # The cache is optional -- absent on a first run -- so it is only checked
+    # when it exists and when --soup will actually read it.
+    #
+    # It is validated HERE rather than in read_cached_packages because by that
+    # point detect_packages has already populated @detected_packages. A parse
+    # error raised there escapes through the ensure-block save, which then
+    # rewrites .soup.json with metadata-less entries and blanks docs/soup.md --
+    # silently discarding previously entered IEC 62304 risk, requirements and
+    # verification reasoning. Failing before any state exists lets save_files'
+    # empty-state guard keep both files untouched.
+    def validate_cache_file!
+      return unless @options.soup_check
+      return unless File.exist?(@options.cache_file)
+
+      validate_json!(@options.cache_file, label: 'cache file')
+    end
+
+    def validate_json!(file, label: 'configuration file')
+      JSON.parse(File.read(file))
+    rescue JSON::ParserError => e
+      raise(ConfigurationError, "Invalid JSON in #{label} #{file}: #{e.message}")
     end
 
     def markdown_cell(value)

--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -305,6 +305,37 @@ RSpec.describe(SOUP::Application) do
       end
     end
 
+    # CFG-001: the cache was the only JSON input not validated at startup.
+    # read_cached_packages parsed it AFTER detect_packages had populated
+    # @detected_packages, so a raw JSON::ParserError escaped through the
+    # ensure-block save -- rewriting .soup.json with metadata-less entries and
+    # blanking docs/soup.md, discarding previously entered IEC 62304 risk,
+    # requirements and verification reasoning. Composer is stubbed here so
+    # detection genuinely populates state; without the fix save_files' empty
+    # -state guard would not fire and both files would be clobbered.
+    context 'when the cache file has invalid JSON' do
+      def corrupt_cache = '{"existing/pkg": {"version": "1.0.0"'
+
+      def existing_markdown = "# Existing SOUP\n"
+
+      before do
+        stub_composer_files(default_composer_lock, default_composer_json)
+        write_existing_soup_files(corrupt_cache, existing_markdown)
+      end
+
+      it 'raises a ConfigurationError naming the cache file' do
+        expect { described_class.new(soup_args(skip: skip_parsers_except_composer)).execute }
+          .to(raise_error(SOUP::ConfigurationError, /Invalid JSON in cache file/))
+      end
+
+      it 'leaves the existing cache and markdown untouched', :aggregate_failures do
+        expect { described_class.new(soup_args(skip: skip_parsers_except_composer)).execute }
+          .to(raise_error(SOUP::ConfigurationError))
+        expect(File.read(cache_file.path)).to(eq(corrupt_cache))
+        expect(File.read(markdown_file)).to(eq(existing_markdown))
+      end
+    end
+
     context 'when config file has invalid JSON' do
       let(:bad_file) do
         file = Tempfile.new(['bad', '.json'])


### PR DESCRIPTION
## Summary

`validate_config!` fail-fast checked `licenses_file` and `exceptions_file`, but `read_cached_packages` did an unguarded `JSON.parse(File.read(cache_file))`. A corrupt or truncated `.soup.json` therefore raised a raw `JSON::ParserError` mid-run instead of a `SOUP::ConfigurationError` — and, worse, destroyed data on the way out.

**Key changes:**

- `lib/soup/application.rb`: extracted `validate_json!(file, label:)` and added `validate_cache_file!`, gated on `soup_check` and `File.exist?` since the cache is optional on a first run. The cache error is labelled `cache file` rather than `configuration file` so the message is accurate; the existing message for licenses/exceptions is unchanged
- `spec/soup/application_spec.rb`: added the CFG-001 regression test — one example asserting `ConfigurationError` names the cache file, one asserting neither `.soup.json` nor `docs/soup.md` is modified

### Why this belongs in `validate_config!` and not a rescue

The issue offered both options, but only one satisfies its own Testing Details. The order in `execute` is decisive:

```
validate_config!  ->  detect_packages  ->  read_cached_packages  ->  ... ensure: save_files
```

By the time `read_cached_packages` parses the cache, `@detected_packages` is already populated — so `save_files`' empty-state guard (from BUG-08) does **not** fire and the ensure-block writes. Validating before any state exists lets that guard keep both files untouched.

### The regression test reproduces the data loss verbatim

Against the old code it does not merely report the wrong error class; it shows the destruction:

```
2.2) expected: "{\"existing/pkg\": {\"version\": \"1.0.0\""
          got: "{ \"valid/pkg\": { ... \"risk_level\": \"\", \"requirements\": \"\",
                 \"verification_reasoning\": \"\" } }"
2.3) expected: "# Existing SOUP\n"
          got: ""
```

`.soup.json` rewritten with metadata-less entries and `docs/soup.md` blanked — exactly the IEC 62304 risk / requirements / verification data loss the issue warns about. Composer is stubbed deliberately so detection genuinely populates state; without that the empty-state guard would mask the bug and the test would pass for the wrong reason.

### Verified end to end

A real run against a corrupt cache prints `Error: Invalid JSON in cache file .soup.json: expected ',' or '}' after object value...` and leaves both files intact, with `"risk_level": "High"` still present. Exit codes confirmed: corrupt cache + `--soup` -> 1; corrupt cache + `--licenses` only -> 0 (the cache is never read in that mode, so the validation is correctly gated); valid cache + `--soup` -> 0.

Full suite 288 examples, 0 failures; line coverage 98.81% -> 98.82%; branch coverage 89.49% -> 89.63%; RuboCop clean across all 39 files.

Out of scope and untouched, per the issue: the broader ensure-block save semantics (BUG-001).

Closes #378

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
