### PR TITLE
#377: build the Docker image from the build context, not master HEAD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep image builds reproducible now that the Dockerfile COPYs the build context
+# instead of cloning: excluding version-control metadata and locally generated
+# artifacts means a build from a developer's working copy produces the same image
+# as one from a clean CI checkout.
+#
+# config/ is deliberately NOT excluded -- Options defaults licenses_file and
+# exceptions_file to config/*.json inside the installed tree, so the tool needs
+# them at runtime.
+
+# Version control and CI definitions
+.git
+.gitignore
+.github
+
+# Locally generated test and coverage artifacts
+coverage
+.rspec_status
+
+# Editor and OS noise
+.DS_Store
+.idea
+.ruby-lsp

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,17 @@ RUN apt-get update && apt-get install --no-install-recommends --yes autoconf aut
 # Add user soup
 RUN useradd -m -s /bin/bash soup && echo 'soup ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
-# Clone the soup repository
-USER soup
-WORKDIR /home/soup
-RUN git clone https://github.com/Cloud-Officer/soup.git
+# Copy the build context -- the exact commit this image is built from -- rather
+# than cloning the default branch at build time. The publishing workflow checks
+# out the tagged commit and passes it as the build context (context: .), but a
+# `git clone` here ignored that entirely and fetched master HEAD over the
+# network. An image tagged vX.Y.Z could therefore contain code that was never in
+# that tag, the amd64 and arm64 builds could pick up different commits, and the
+# provenance attestation would attest a revision that is not what shipped.
+# Copying also makes the build hermetic and removes the stale-layer-cache risk.
+COPY --chown=soup:soup . /home/soup/soup
 
 # Install soup dependencies and create a symlink
-USER root
 WORKDIR /home/soup/soup
 RUN bundle install && ln -s "/home/soup/soup/bin/soup.rb" "/usr/local/bin/soup"
 


### PR DESCRIPTION
## Summary

The published Docker image was built by cloning the default branch at build time (`RUN git clone https://github.com/Cloud-Officer/soup.git`), while `.github/workflows/docker.yml` publishes on tag pushes. The Dockerfile ignored the build context entirely and fetched master HEAD over the network — so an image tagged `vX.Y.Z` could contain code that was never in that tag.

I read the shared publishing action first (read-only; not changed, per Out of Scope). `cloud-officer/ci-actions/docker@v2` runs `actions/checkout@v7`, then `docker/build-push-action@v7` with `context: .`, `file: ./Dockerfile`, `platforms: linux/amd64,linux/arm64`, then `actions/attest-build-provenance@v4`. **The workflow was already handing the Dockerfile the tagged tree** — the `git clone` simply threw it away, and the attestation signed a revision that was not what shipped.

**Key changes:**

- `Dockerfile`: replaced the clone with `COPY --chown=soup:soup . /home/soup/soup`. The `--chown` preserves the ownership the clone produced when it ran as `USER soup`. Also dropped the now-redundant `USER soup` / `USER root` toggling, since `COPY` runs as root regardless
- `.dockerignore`: added. Without it `COPY .` would pull in `.git` (2.4 MB) plus locally generated `coverage/` and `.rspec_status`, so a developer's build would differ from a clean CI build — undermining the reproducibility this issue is about. It excludes only VCS metadata, CI definitions, and generated/editor artifacts

**`config/` is deliberately not excluded.** `lib/soup/options.rb` defaults `licenses_file` and `exceptions_file` to `#{__dir__}/../../config/*.json` inside the installed tree, so the tool needs `config/` at runtime. Excluding it would have produced a broken image that still built cleanly.

### Proven by building both images

A marker file that exists only in the working tree and has never been on master was added, then both Dockerfiles were built from the same context:

| | marker in image? | `.git` |
| --- | --- | --- |
| Old (`RUN git clone`) | **absent** — image does not match the build context | present (cloned) |
| New (`COPY . ...`) | **present** — image matches the build context | absent |

Also confirmed the new image contains this branch's code, retains `config/`, and that `soup --help` runs inside the container. The marker file and both test images were removed afterwards.

### Test gate — explicit no-test exception

No unit tests were added because no `lib/` or `spec/` code changed. This is **build configuration**, one of the stated exception categories, and it has no unit-testable logic. The real verification was building both images and comparing their contents, which a unit test cannot do.

Verification: `hadolint` with the repo's `.hadolint.yaml` reports no offenses; full suite 288 examples, 0 failures; line coverage 98.82% and branch coverage 89.63%, both unchanged since no Ruby code was touched; RuboCop clean across all 39 files.

Closes #377

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: No `lib/` or `spec/` code changed — this is build configuration with no unit-testable logic. Verified instead by building the old and new images and comparing their contents.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [x] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
