### PR TITLE
Fix #376: stop rewriting Unlicense to NOASSERTION so its allowlist entry works

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,7 +236,7 @@
 - `parallel_each(work_items, packages, &)`: Fetches metadata for the work items concurrently via `Parallel.map(..., in_threads: HttpClient::THREAD_COUNT)` and collects the results
 - `collect_packages(results, packages)`: Compacts the fetched results and keys them by package name into the packages hash
 - `build_package(...)`: Constructs a `SOUP::Package` with normalized fields
-- `normalize_license(license)`: Maps Unlicense and URL-style license values to `NOASSERTION`; `UNLICENSE_PATTERN` is the private constant it matches on
+- `normalize_license(license)`: Maps URL-style license values (a link to a licence file names no licence) to `NOASSERTION`; every named identifier, `Unlicense` included, passes through so the `config/licenses.json` allowlist can match it
 - `sibling_file(file, suffix)`: Resolves a sibling manifest path next to a lock file
 - `manifest_mentions?(main_file, token)`: Token-boundary test for whether a dependency is declared directly in a source-code manifest; matches only when `token` is not flanked by identifier characters so a name that is a substring of another coordinate (e.g. `androidx.core:core` vs `androidx.core:core-ktx`) is not misclassified. Used by the Gradle and SPM parsers
 - `lookup_npm_registry_version(payload, name:, version:)`: Extracts a specific version hash from an npm-style registry payload; shared by the NPM, Yarn, and Importmap parsers

--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -11,9 +11,6 @@ module SOUP
     NOASSERTION_LICENSE = 'NOASSERTION'
     public_constant :NOASSERTION_LICENSE
 
-    UNLICENSE_PATTERN = 'Unlicense'
-    private_constant :UNLICENSE_PATTERN
-
     NPM_REGISTRY_ROOT = 'https://registry.npmjs.org'
     private_constant :NPM_REGISTRY_ROOT
 
@@ -71,10 +68,21 @@ module SOUP
       package
     end
 
+    # Downgrade a license value that carries no usable identity to NOASSERTION.
+    #
+    # Only a URL qualifies: registries let publishers point at a licence file
+    # instead of naming one ("https://github.com/x/y/blob/main/LICENSE"), and a
+    # URL states nothing Application#validate_license can match against the
+    # allowlist -- NOASSERTION is the honest SPDX answer.
+    #
+    # Everything else passes through verbatim, "Unlicense" included. It is a
+    # real SPDX identifier (the public-domain dedication) and config/licenses.json
+    # allowlists it, so rewriting it here made that entry unreachable and warned
+    # "Invalid license NOASSERTION" on every run for a licence the project had
+    # deliberately accepted.
     def normalize_license(license)
       return license if license.nil?
       return license if license.respond_to?(:empty?) && license.empty?
-      return NOASSERTION_LICENSE if license.to_s.include?(UNLICENSE_PATTERN)
       return NOASSERTION_LICENSE if license.to_s.start_with?('http')
 
       license

--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -427,6 +427,41 @@ RSpec.describe(SOUP::Application) do
       end
     end
 
+    # BUG-006: config/licenses.json allowlists "Unlicense", but every parser
+    # routed it through normalize_license, which rewrote it to NOASSERTION
+    # before validate_license ran. The allowlist entry was therefore dead and
+    # every Unlicense package warned "Invalid license NOASSERTION" on each run.
+    context 'with an allowlisted Unlicense package' do
+      before do
+        File.write(licenses_file.path, '["MIT", "Apache-2.0", "Unlicense"]')
+        unlicense_lock = {
+          packages: [
+            {
+              name: 'unlicense/pkg',
+              version: '1.0.0',
+              license: ['Unlicense'],
+              description: 'Public domain package',
+              homepage: 'https://example.com'
+            }
+          ],
+          'packages-dev': []
+        }.to_json
+        stub_composer_files(unlicense_lock, '{"require":{"unlicense/pkg":"^1.0"}}')
+      end
+
+      it 'validates against the allowlist without warning', :aggregate_failures do
+        app = described_class.new(licenses_args(skip: skip_parsers_except_composer))
+        expect { expect(app.execute).to(eq(SOUP::Status::SUCCESS_EXIT_CODE)) }
+          .not_to(output(/Invalid license/).to_stderr)
+      end
+
+      it 'records the license as Unlicense rather than NOASSERTION' do
+        app = described_class.new(soup_args(skip: skip_parsers_except_composer))
+        app.execute
+        expect(JSON.parse(File.read(cache_file.path))['unlicense/pkg']['license']).to(eq('Unlicense'))
+      end
+    end
+
     context 'with partial state on failure' do
       before do
         two_pkg_lock = {

--- a/spec/soup/base_parser_spec.rb
+++ b/spec/soup/base_parser_spec.rb
@@ -66,8 +66,16 @@ RSpec.describe(SOUP::BaseParser) do
         expect(parser.normalize_license('')).to(eq(''))
       end
 
-      it 'converts Unlicense to NOASSERTION' do
-        expect(parser.normalize_license('Unlicense')).to(eq('NOASSERTION'))
+      # BUG-006: Unlicense is a real SPDX identifier and config/licenses.json
+      # allowlists it, but normalize_license rewrote it to NOASSERTION before
+      # validation ever saw it -- making the allowlist entry unreachable and
+      # warning "Invalid license NOASSERTION" on every run.
+      it 'passes Unlicense through so the allowlist entry stays reachable' do
+        expect(parser.normalize_license('Unlicense')).to(eq('Unlicense'))
+      end
+
+      it 'passes the "The Unlicense" spelling through as well' do
+        expect(parser.normalize_license('The Unlicense')).to(eq('The Unlicense'))
       end
 
       it 'converts a URL license to NOASSERTION' do

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -124,10 +124,12 @@ RSpec.describe(SOUP::NPMParser) do
         .to_return(status: 200, body: unlicense_response)
     end
 
-    it 'converts Unlicense to NOASSERTION' do
+    # BUG-006: Unlicense is allowlisted in config/licenses.json, so it must
+    # survive parsing intact rather than being downgraded to NOASSERTION.
+    it 'records Unlicense verbatim' do
       packages = {}
       parser.parse(lockfile_path, packages)
-      expect(packages['lodash'].license).to(eq('NOASSERTION'))
+      expect(packages['lodash'].license).to(eq('Unlicense'))
     end
   end
 

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -203,10 +203,12 @@ RSpec.describe(SOUP::YarnParser) do
         .to_return(status: 200, body: unlicense_response)
     end
 
-    it 'converts Unlicense to NOASSERTION' do
+    # BUG-006: Unlicense is allowlisted in config/licenses.json, so it must
+    # survive parsing intact rather than being downgraded to NOASSERTION.
+    it 'records Unlicense verbatim' do
       packages = {}
       parser.parse(lockfile_path, packages)
-      expect(packages['lodash'].license).to(eq('NOASSERTION'))
+      expect(packages['lodash'].license).to(eq('Unlicense'))
     end
   end
 


### PR DESCRIPTION
## Summary

`normalize_license` rewrote any license containing `Unlicense` to `NOASSERTION` before validation ran, so the `"Unlicense"` entry that commit ff936eb deliberately added to `config/licenses.json` was unreachable. Every Unlicense-licensed package warned `Invalid license NOASSERTION` on each run, for a licence the project had explicitly accepted. `Unlicense` is a real SPDX identifier (the public-domain dedication), so this drops the rewrite and lets it reach the allowlist. The URL rule stays: a link to a licence file names no licence, so `NOASSERTION` remains the honest answer there.

**Key changes:**

- Removed the `Unlicense` to `NOASSERTION` rewrite and the now-unused `UNLICENSE_PATTERN` private constant from `lib/soup/parsers/base.rb`, leaving only the URL rule, and documented why the two cases differ
- Added an end-to-end regression context in `spec/soup/application_spec.rb` for an allowlisted Unlicense package: it asserts a success exit code with no `Invalid license` on stderr, and that the register records `Unlicense` instead of `NOASSERTION` (both examples fail before the fix)
- Inverted the three specs that asserted the old behaviour in `spec/soup/base_parser_spec.rb`, `spec/soup/npm_parser_spec.rb` and `spec/soup/yarn_parser_spec.rb`, and added coverage for the `The Unlicense` spelling
- Corrected the `normalize_license` entry in `docs/architecture.md`, which documented the buggy mapping and referenced the deleted constant
- No manual reprocessing needed: a resolved package's fresh parse wins over the cached license, so `.soup.json` and `docs/soup.md` rows for Unlicense packages move from `NOASSERTION` to `Unlicense` on the next run

Fixes #376

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
