### PR TITLE
Fix #375: retry every transient network fault, not only timeouts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,12 +207,15 @@
 - `THREAD_COUNT`: Public constant set to `Etc.nprocessors`; used by all parsers as the thread-pool size for parallel metadata fetching
 - `self.max_retries`: Returns the retry count, overridable at runtime via the `SOUP_HTTP_MAX_RETRIES` environment variable
 - `self.default_timeout`: Returns the request timeout in seconds, overridable at runtime via the `SOUP_HTTP_TIMEOUT` environment variable
-- `self.get(url, max_retries: nil, **options)`: Performs HTTP GET with automatic retry on `Net::OpenTimeout` and `Net::ReadTimeout`
+- `TRANSIENT_ERRORS`: Public constant listing every network fault treated as retryable — the timeouts (`Net::OpenTimeout`, `Net::ReadTimeout`, `Net::WriteTimeout`), dropped or refused connections (`Errno::ECONNRESET`, `Errno::EPIPE`, `Errno::ECONNREFUSED`, `Errno::EHOSTUNREACH`, `Errno::ENETUNREACH`), DNS failure (`SocketError`), TLS interruption (`OpenSSL::SSL::SSLError`), and truncated replies (`EOFError`, `Net::HTTPBadResponse`). It is the single source of truth: `self.get` retries this list and `BaseParser#registry_response` rescues this same constant, so the two can never drift apart. HTTP status codes are deliberately excluded — a 4xx/5xx is a response for the caller to inspect, not a transport failure
+- `self.get(url, max_retries: nil, **options)`: Performs HTTP GET with automatic retry on every class in `TRANSIENT_ERRORS`, warning with the exception class and message on each attempt and re-raising once retries are exhausted
 
 **External Dependencies:**
 
 - `etc`
 - `httparty`
+- `net/http` (for the `Net::` timeout and bad-response classes in `TRANSIENT_ERRORS`)
+- `openssl` (for `OpenSSL::SSL::SSLError` in `TRANSIENT_ERRORS`)
 
 ### SOUP::GenericParser
 
@@ -285,7 +288,7 @@
 
 - `parse(file, packages)`: Parses lock file and fetches package details, in parallel via the inherited `parallel_each` helper (`BaseParser`). Selects `classpath` entries for `buildscript-gradle.lockfile` and non-test, non-debug `RuntimeClasspath` entries for `gradle.lockfile`
 - `fetch_package(...)`: Queries the `search.maven.org` solrsearch endpoint first; when it returns no single match, or times out (the endpoint is chronically flaky), the lookup degrades to the per-repository POM mirrors in `REPOSITORY_URLS` rather than aborting the run. A coordinate that no source resolves is warned and skipped
-- `safe_get(url)`: Wraps `HttpClient.get` so a `Net::OpenTimeout`/`Net::ReadTimeout` on one mirror is swallowed (warned, returns nil) and the caller falls through to the next source, instead of `Parallel.map` propagating the exception and aborting every other in-flight lookup
+- Mirror failures are absorbed by the inherited `BaseParser#registry_response`, which swallows any `HttpClient::TRANSIENT_ERRORS` fault on one mirror (warned, returns nil) so the caller falls through to the next source, instead of `Parallel.map` propagating the exception and aborting every other in-flight lookup. It is passed an explicit `outcome` (`trying the per-repository POM fallbacks`, then `trying the next repository`) so the warning does not claim the package was recorded
 - `read_main_gradle_file(file)`: Resolves the build script next to the lock file, trying the Groovy DSL `build.gradle` then the Kotlin DSL `build.gradle.kts` (the Gradle 8.x+ default for new Android/Kotlin projects); raises `InvalidLockfileError` when neither exists. The contents are passed to `manifest_mentions?` for direct/transitive classification
 - `unresolved_message(response, url:, package:)`: Builds the skip warning, falling back to an "all Maven lookups timed out" message when every source timed out and there is no HTTP status to report
 - `REPOSITORY_URLS`: Private constant listing the Maven POM mirror URLs (`maven.google.com`, `plugins.gradle.org/m2`, `jitpack.io`, the Sonatype snapshots repo) tried in order when the primary endpoint has no match
@@ -514,11 +517,13 @@ Validation criteria for SOUP entries: Accuracy (Requirements match actual usage)
 **Implementation:**
 
 1. Attempts HTTP GET request with the configured timeout (`DEFAULT_TIMEOUT_SECONDS`, 5 seconds by default; overridable via `SOUP_HTTP_TIMEOUT`)
-2. On `Net::OpenTimeout` or `Net::ReadTimeout`:
+2. On any class in `TRANSIENT_ERRORS` (timeouts, connection resets/refusals, DNS failures, TLS interruptions, truncated replies):
    - Increments retry counter
-   - Logs retry attempt with counter
+   - Logs the retry attempt with the exception class, message, and counter
    - Retries up to the configured maximum (`DEFAULT_MAX_RETRIES`, 3 by default; overridable via `SOUP_HTTP_MAX_RETRIES`)
-   - Raises the exception after max retries are exhausted
+   - Raises the exception after max retries are exhausted, for `BaseParser#registry_response` to convert into a per-package skip
+
+   Restricting this list to the two timeout classes was the ERR-001 defect: every other transient fault bypassed the retry loop on its first attempt and escaped into `Parallel.map`, which propagates the first exception and drops every other in-flight result — so a single connection reset aborted an entire multi-hundred-package scan.
 
 ### Parallel Metadata Fetching Algorithm
 
@@ -554,13 +559,13 @@ Recoverable failures raise a subclass of `SOUP::Error` (`lib/soup/errors.rb`); t
 | Missing or malformed config file | Raises `ConfigurationError` when a configuration file is absent or contains invalid JSON | `lib/soup/application.rb` in `validate_config!` method |
 | API rate limiting | Raises `RateLimitError` (and `AuthenticationError` for bad credentials), suggesting `GITHUB_TOKEN` | `lib/soup/parsers/spm.rb` in `fetch_package` / `github_error_message` methods |
 | Network timeouts | Retry up to 3 times via `SOUP::HttpClient`, then re-raise | `lib/soup/http_client.rb` in `get` method |
-| Registry timeout after retries | The single package is warned about and omitted from the SOUP register rather than aborting the scan | `lib/soup/parsers/npm.rb`, `yarn.rb`, `importmap.rb` in `fetch_package` methods |
+| Transient network fault after retries | Any `HttpClient::TRANSIENT_ERRORS` fault (timeout, connection reset/refusal, DNS failure, TLS interruption, truncated reply) is retried, then the single package is warned about and recorded as unresolved rather than aborting the scan | `lib/soup/parsers/base.rb` in `registry_response`, used by every parser |
 | Non-2xx registry response | Raises `RegistryError` carrying the status, URL, package, and truncated body built by `http_error_message` | `lib/soup/parsers/bundler.rb`, `pip.rb`, `yarn.rb` in `fetch_package` methods |
 | Unsupported lock file format | Raises `UnsupportedFormatError` for a `package-lock.json` below `lockfileVersion` 2 and for a `yarn.lock` that is not Yarn v1 | `lib/soup/parsers/npm.rb`, `yarn.rb` in `parse` methods |
 | Malformed manual entries file | Raises `InvalidLockfileError` when the file is not a JSON array or an entry lacks a non-empty `package` | `lib/soup/parsers/manual.rb` in `parse` method |
 | Missing Gradle build script | Raises `InvalidLockfileError` when neither `build.gradle` nor `build.gradle.kts` sits alongside the lock file | `lib/soup/parsers/gradle.rb` in `read_main_gradle_file` method |
 | Missing Swift manifest | Raises `InvalidLockfileError` when no `Package.swift`, Tuist `Dependencies.swift`, or enclosing `project.pbxproj` can be resolved for a `Package.resolved` | `lib/soup/parsers/spm.rb` in `parse` / `read_main_swift_file` methods |
-| Maven source timeout | A timed-out `search.maven.org` query or POM mirror is skipped (warned) and the lookup falls through to the next source; the scan is not aborted | `lib/soup/parsers/gradle.rb` in `fetch_package` / `safe_get` methods |
+| Maven source unreachable | An unreachable `search.maven.org` query or POM mirror is skipped (warned) and the lookup falls through to the next source; the scan is not aborted | `lib/soup/parsers/gradle.rb` in `fetch_package`, via `BaseParser#registry_response` |
 | Missing package metadata | Logs warning and continues processing other packages | NPM, Gradle, SPM, Importmap parsers; `lookup_npm_registry_version` in `lib/soup/parsers/base.rb` |
 | Missing required IEC 62304 fields | Raises `MissingMetadataError` in `--no_prompt` mode, prompts user otherwise | `lib/soup/application.rb` in `prompt_missing_field` / `ensure_metadata_complete!` methods |
 | Partial execution failure | Persists partial state via `ensure` block so progress is not lost | `lib/soup/application.rb` in `execute` method |

--- a/lib/soup/http_client.rb
+++ b/lib/soup/http_client.rb
@@ -2,6 +2,8 @@
 
 require 'etc'
 require 'httparty'
+require 'net/http'
+require 'openssl'
 
 module SOUP
   module HttpClient
@@ -14,8 +16,44 @@ module SOUP
     DEFAULT_TIMEOUT_SECONDS = 5
     THREAD_COUNT = Etc.nprocessors
 
+    # Every network fault that is worth another attempt, and the single source
+    # of truth for "transient" across the codebase: `.get` retries these and
+    # BaseParser#registry_response rescues this same list. Keeping one list is
+    # the point -- when the retry set and the parser rescue set were maintained
+    # separately, they drifted to timeouts-only and a lone connection reset
+    # escaped into Parallel.map, which propagates the first exception and
+    # aborted every other in-flight lookup in the scan.
+    #
+    # - Net::OpenTimeout / ReadTimeout / WriteTimeout: registry slow or wedged
+    # - Errno::ECONNRESET / EPIPE: peer or proxy dropped an established socket
+    # - Errno::ECONNREFUSED / EHOSTUNREACH / ENETUNREACH: mirror down or a
+    #   routing blip; a Gradle mirror loop wants to fall through to the next one
+    # - SocketError: DNS resolution failure, routinely momentary in CI
+    # - OpenSSL::SSL::SSLError: TLS handshake interrupted mid-negotiation
+    # - EOFError / Net::HTTPBadResponse: connection closed or truncated
+    #   mid-response, leaving an unparseable reply
+    #
+    # Deliberately excluded: HTTP status codes. A 4xx/5xx is a *response*, not a
+    # transport failure -- callers inspect `response.code` and decide, and SPM's
+    # rate-limit and bad-credentials handling still aborts on purpose because
+    # those are global conditions that would fail every remaining lookup.
+    TRANSIENT_ERRORS = [
+      Net::OpenTimeout,
+      Net::ReadTimeout,
+      Net::WriteTimeout,
+      Net::HTTPBadResponse,
+      Errno::ECONNRESET,
+      Errno::ECONNREFUSED,
+      Errno::EHOSTUNREACH,
+      Errno::ENETUNREACH,
+      Errno::EPIPE,
+      SocketError,
+      OpenSSL::SSL::SSLError,
+      EOFError
+    ].freeze
+
     private_constant :DEFAULT_MAX_RETRIES, :DEFAULT_TIMEOUT_SECONDS
-    public_constant :THREAD_COUNT
+    public_constant :THREAD_COUNT, :TRANSIENT_ERRORS
 
     def self.max_retries
       Integer(ENV.fetch('SOUP_HTTP_MAX_RETRIES', DEFAULT_MAX_RETRIES))
@@ -31,15 +69,15 @@ module SOUP
 
       begin
         HTTParty.get(url, { timeout: default_timeout }.merge(options))
-      rescue Net::OpenTimeout, Net::ReadTimeout => e
+      rescue *TRANSIENT_ERRORS => e
         retries += 1
 
         if retries <= max_retries
-          warn("Error: #{e.message}. Retrying (#{retries}/#{max_retries})...")
+          warn("Error: #{e.class}: #{e.message}. Retrying (#{retries}/#{max_retries})...")
           retry
         end
 
-        warn("Error: #{e.message}. Aborting after #{max_retries} retries.")
+        warn("Error: #{e.class}: #{e.message}. Aborting after #{max_retries} retries.")
         raise
       end
     end

--- a/lib/soup/parsers/base.rb
+++ b/lib/soup/parsers/base.rb
@@ -148,10 +148,10 @@ module SOUP
       "#{NPM_REGISTRY_ROOT}/#{name}"
     end
 
-    # GET a registry URL, absorbing the timeout HttpClient re-raises once its
-    # retries are exhausted. Parallel.map propagates the first exception and
+    # GET a registry URL, absorbing the network fault HttpClient re-raises once
+    # its retries are exhausted. Parallel.map propagates the first exception and
     # aborts every other in-flight lookup, so one unreachable registry must not
-    # kill the whole scan. Returns nil on timeout, so callers guard with
+    # kill the whole scan. Returns nil on failure, so callers guard with
     # `return if response.nil?` -- or, for a multi-source loop, fall through to
     # the next source. Every parser that talks to a registry routes through here.
     #
@@ -165,10 +165,16 @@ module SOUP
     # then record the package via unresolved_package. Only SPM's rate-limit and
     # bad-credentials responses still abort, because those are global conditions
     # that would fail every remaining lookup identically.
+    #
+    # The rescue list is HttpClient::TRANSIENT_ERRORS itself rather than a
+    # hand-copied set, so it can never again fall behind what `.get` retries --
+    # the drift that let a connection reset abort an entire scan. The warning
+    # names the exception class because "timeout" was previously claimed for
+    # every fault, which misdescribed resets, DNS failures and TLS errors.
     def registry_response(url, label:, outcome: 'recorded without registry metadata', **)
       HttpClient.get(url, **)
-    rescue Net::OpenTimeout, Net::ReadTimeout => e
-      warn("Skipping #{label}: network timeout after retries (#{e.message}); #{outcome}")
+    rescue *HttpClient::TRANSIENT_ERRORS => e
+      warn("Skipping #{label}: network error after retries (#{e.class}: #{e.message}); #{outcome}")
       nil
     end
 

--- a/spec/soup/base_parser_spec.rb
+++ b/spec/soup/base_parser_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe(SOUP::BaseParser) do
                :normalize_license,
                :npm_registry_license,
                :sibling_file,
+               :registry_response,
                :http_error_message
       end
     end
@@ -115,6 +116,76 @@ RSpec.describe(SOUP::BaseParser) do
       it 'does not corrupt a directory whose name contains the lockfile name' do
         expect(parser.sibling_file('/Users/sherlock/composer.lock', 'composer.json'))
           .to(eq('/Users/sherlock/composer.json'))
+      end
+    end
+
+    # ERR-001: registry_response is the single parser-level rescue every parser
+    # routes through. Its rescue list used to be a hand-copied
+    # "Net::OpenTimeout, Net::ReadTimeout", so any other transient fault escaped
+    # into Parallel.map and aborted the entire scan. It now rescues
+    # HttpClient::TRANSIENT_ERRORS itself, which cannot drift from what .get
+    # retries.
+    describe '#registry_response' do
+      let(:url) { 'https://registry.example.com/pkg' }
+      # One healthy package, one that resets, one more healthy -- routed through
+      # the same parallel_each every parser uses.
+      let(:mixed_batch) do
+        lambda do |packages|
+          parser.parallel_each(%w[good bad good2], packages) do |name|
+            target = name == 'bad' ? "#{url}/bad" : "#{url}/good"
+            build_block.call("pkg-#{name}") if parser.registry_response(target, label: name, max_retries: 0)
+          end
+        end
+      end
+
+      # max_retries: 0 keeps each example to a single request -- the retry
+      # behaviour itself is HttpClient's contract and is covered there.
+      SOUP::HttpClient::TRANSIENT_ERRORS.each do |error_class|
+        it "returns nil and warns instead of letting #{error_class} abort the scan", :aggregate_failures do
+          stub_request(:get, url).to_raise(error_class)
+
+          result = nil
+          expect { result = parser.registry_response(url, label: 'pkg', max_retries: 0) }
+            .to(output(/Skipping pkg: network error after retries/).to_stderr)
+          expect(result).to(be_nil)
+        end
+      end
+
+      it 'names the exception class rather than calling every fault a timeout' do
+        stub_request(:get, url).to_raise(Errno::ECONNRESET)
+
+        expect { parser.registry_response(url, label: 'pkg', max_retries: 0) }
+          .to(output(/Errno::ECONNRESET/).to_stderr)
+      end
+
+      it 'reports the caller-supplied outcome so gradle\'s mirror loop is not misdescribed' do
+        stub_request(:get, url).to_raise(SocketError)
+
+        expect { parser.registry_response(url, label: url, outcome: 'trying next repository', max_retries: 0) }
+          .to(output(/trying next repository/).to_stderr)
+      end
+
+      it 'passes a successful response straight through' do
+        stub_request(:get, url).to_return(status: 200, body: 'ok')
+        expect(parser.registry_response(url, label: 'pkg').code).to(eq(200))
+      end
+
+      # A non-2xx is a response, not a transport fault: callers inspect the code
+      # themselves, so it must not be swallowed into nil here.
+      it 'returns a non-2xx response rather than converting it to nil' do
+        stub_request(:get, url).to_return(status: 404, body: 'Not Found')
+        expect(parser.registry_response(url, label: 'pkg').code).to(eq(404))
+      end
+
+      # The whole point of ERR-001: Parallel.map propagates the first exception
+      # and drops every other in-flight result, so a single reset used to cost
+      # the entire run. The surviving packages must still be collected.
+      it 'lets the rest of a parallel batch survive one package\'s connection reset' do
+        stub_request(:get, "#{url}/bad").to_raise(Errno::ECONNRESET)
+        stub_request(:get, "#{url}/good").to_return(status: 200, body: 'ok')
+        packages = {}
+        mixed_batch.call(packages)
+        expect(packages.keys).to(contain_exactly('pkg-good', 'pkg-good2'))
       end
     end
 

--- a/spec/soup/bundler_parser_spec.rb
+++ b/spec/soup/bundler_parser_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe(SOUP::BundlerParser) do
 
     it 'names the gem in the skip warning' do
       expect { parser.parse('Gemfile.lock', packages) }
-        .to(output(/Skipping test-gem 1\.0\.0: network timeout after retries/).to_stderr)
+        .to(output(/Skipping test-gem 1\.0\.0: network error after retries/).to_stderr)
     end
   end
 
@@ -139,7 +139,7 @@ RSpec.describe(SOUP::BundlerParser) do
 
       it 'records the gem and names the resolved version in the warning', :aggregate_failures do
         expect { parser.parse('Gemfile.lock', packages) }
-          .to(output(/Skipping test-gem 2\.0\.0: network timeout after retries/).to_stderr)
+          .to(output(/Skipping test-gem 2\.0\.0: network error after retries/).to_stderr)
         expect(packages['test-gem']).to(have_attributes(version: '1.0.0', license: 'NOASSERTION'))
       end
     end

--- a/spec/soup/http_client_spec.rb
+++ b/spec/soup/http_client_spec.rb
@@ -55,11 +55,8 @@ RSpec.describe(SOUP::HttpClient) do
       expect(WebMock).to(have_requested(:get, url).times(2))
     end
 
-    # TEST-06: HttpClient.get is a thin retry wrapper that only catches
-    # Net::OpenTimeout / Net::ReadTimeout. These specs lock in the contract
-    # that non-timeout transient errors pass through unchanged (no retry),
-    # and that 4xx/5xx responses are returned to the caller for inspection
-    # rather than raised internally.
+    # TEST-06: 4xx/5xx are *responses*, not transport failures -- they are
+    # returned to the caller for inspection rather than retried or raised.
     it 'returns a 404 response unchanged so callers can decide how to handle it', :aggregate_failures do
       stub_request(:get, url).to_return(status: 404, body: 'Not Found')
       response = described_class.get(url)
@@ -74,18 +71,40 @@ RSpec.describe(SOUP::HttpClient) do
       expect(WebMock).to(have_requested(:get, url).times(1))
     end
 
-    it 'lets Errno::ECONNREFUSED bypass the retry loop and propagate', :aggregate_failures do
-      stub_request(:get, url).to_raise(Errno::ECONNREFUSED.new("connect to #{url} refused"))
-      expect { described_class.get(url) }
-        .to(raise_error(Errno::ECONNREFUSED))
-      expect(WebMock).to(have_requested(:get, url).times(1))
-    end
+    # ERR-001: the retry set used to be Net::OpenTimeout/ReadTimeout only, so
+    # every other transient fault bypassed the retry loop on its first attempt
+    # and escaped into Parallel.map -- which propagates the first exception and
+    # aborts every other in-flight lookup, killing a whole multi-hundred-package
+    # scan over one connection reset. Two of the examples below previously
+    # asserted that bypass as if it were the intended contract.
+    #
+    # Each transient class must now be retried max_retries times and only then
+    # re-raised, so BaseParser#registry_response can turn it into a per-package
+    # skip. Driven from the constant itself so a class added to TRANSIENT_ERRORS
+    # without retry coverage fails here.
+    describe 'transient network faults' do
+      SOUP::HttpClient::TRANSIENT_ERRORS.each do |error_class|
+        it "retries #{error_class} to exhaustion, warns, then re-raises", :aggregate_failures do
+          stub_request(:get, url).to_raise(error_class)
+          expect { described_class.get(url) }
+            .to(raise_error(error_class).and(output(/Aborting after 3 retries/).to_stderr))
+          expect(WebMock).to(have_requested(:get, url).times(4))
+        end
 
-    it 'lets SocketError bypass the retry loop and propagate', :aggregate_failures do
-      stub_request(:get, url).to_raise(SocketError.new('getaddrinfo: nodename nor servname provided'))
-      expect { described_class.get(url) }
-        .to(raise_error(SocketError, /getaddrinfo/))
-      expect(WebMock).to(have_requested(:get, url).times(1))
+        it "recovers when an attempt after #{error_class} succeeds", :aggregate_failures do
+          stub_request(:get, url).to_raise(error_class).then.to_return(status: 200, body: 'ok')
+          expect { expect(described_class.get(url).code).to(eq(200)) }
+            .to(output(%r{Retrying \(1/3\)}).to_stderr)
+          expect(WebMock).to(have_requested(:get, url).times(2))
+        end
+      end
+
+      it 'names the exception class in the warning so resets are not reported as timeouts' do
+        stub_request(:get, url).to_raise(Errno::ECONNRESET)
+
+        expect { described_class.get(url) }
+          .to(raise_error(Errno::ECONNRESET).and(output(/Errno::ECONNRESET/).to_stderr))
+      end
     end
   end
 

--- a/spec/soup/importmap_parser_spec.rb
+++ b/spec/soup/importmap_parser_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe(SOUP::ImportmapParser) do
 
     it 'records the package and names it without a version in the warning', :aggregate_failures do
       expect { packages }
-        .to(output(/Skipping marked: network timeout after retries/).to_stderr)
+        .to(output(/Skipping marked: network error after retries/).to_stderr)
       expect(packages['marked']).to(have_attributes(version: '12.0.0', license: 'NOASSERTION'))
       expect(packages['marked'].unresolved).to(be(true))
     end

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe(SOUP::NPMParser) do
     # "name@version" -- Importmap, which cannot, deliberately omits it.
     it 'names the package as name@version in the skip warning' do
       expect { parser.parse(lockfile_path, packages) }
-        .to(output(/Skipping lodash@4\.17\.21: network timeout after retries/).to_stderr)
+        .to(output(/Skipping lodash@4\.17\.21: network error after retries/).to_stderr)
     end
   end
 

--- a/spec/soup/pip_parser_spec.rb
+++ b/spec/soup/pip_parser_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe(SOUP::PIPParser) do
 
     it 'names the package as name==version in the skip warning' do
       expect { parser.parse(requirements_path, packages) }
-        .to(output(/Skipping requests==2\.31\.0: network timeout after retries/).to_stderr)
+        .to(output(/Skipping requests==2\.31\.0: network error after retries/).to_stderr)
     end
   end
 

--- a/spec/soup/spm_parser_spec.rb
+++ b/spec/soup/spm_parser_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe(SOUP::SPMParser) do
 
     it 'names the pin in the skip warning' do
       expect { parser.parse(lockfile_path, packages) }
-        .to(output(/Skipping alamofire: network timeout after retries/).to_stderr)
+        .to(output(/Skipping alamofire: network error after retries/).to_stderr)
     end
   end
 

--- a/spec/soup/yarn_parser_spec.rb
+++ b/spec/soup/yarn_parser_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe(SOUP::YarnParser) do
     # passes. A timeout is skipped here even though a non-200 raises.
     it 'names the package as name@version in the skip warning' do
       expect { parser.parse(lockfile_path, packages) }
-        .to(output(/Skipping lodash@4\.17\.21: network timeout after retries/).to_stderr)
+        .to(output(/Skipping lodash@4\.17\.21: network error after retries/).to_stderr)
     end
   end
 


### PR DESCRIPTION
## Summary

`HttpClient.get` retried only `Net::OpenTimeout` and `Net::ReadTimeout`. Every other transient fault — a connection reset, a DNS blip, an interrupted TLS handshake, a truncated reply — bypassed the retry loop on its **first** attempt and escaped into `Parallel.map`, which propagates the first exception and drops every other in-flight result. One reset therefore aborted an entire multi-hundred-package scan.

PR #402 consolidated the four duplicated parser rescues into a single `BaseParser#registry_response`, but moved the two-class list rather than widening it — so the shared helper had the same gap, now governing every parser. The root cause is two hand-maintained rescue lists drifting apart, so the fix removes the possibility of drift rather than just widening one list: `HttpClient::TRANSIENT_ERRORS` is a single frozen constant that `.get` retries and `registry_response` rescues directly.

Verified against `master` before fixing — each class escaped after exactly one attempt, with no retry:

```
Errno::ECONNRESET:      ESCAPED as Errno::ECONNRESET      (attempts=1)
Errno::ECONNREFUSED:    ESCAPED as Errno::ECONNREFUSED    (attempts=1)
SocketError:            ESCAPED as SocketError            (attempts=1)
OpenSSL::SSL::SSLError: ESCAPED as OpenSSL::SSL::SSLError (attempts=1)
EOFError:               ESCAPED as EOFError               (attempts=1)
Net::HTTPBadResponse:   ESCAPED as Net::HTTPBadResponse   (attempts=1)
```

**Key changes:**

- Added `HttpClient::TRANSIENT_ERRORS` in `lib/soup/http_client.rb` — the timeouts plus `Errno::ECONNRESET/EPIPE/ECONNREFUSED/EHOSTUNREACH/ENETUNREACH`, `SocketError`, `OpenSSL::SSL::SSLError`, `EOFError` and `Net::HTTPBadResponse` — and made `.get` retry the whole list; requires `net/http` and `openssl` explicitly rather than relying on HTTParty to pull them in
- Changed `BaseParser#registry_response` in `lib/soup/parsers/base.rb` to `rescue *HttpClient::TRANSIENT_ERRORS`, referencing the constant itself so the parser rescue can never again fall behind what `.get` retries
- Warnings now name the exception class (`network error after retries (Errno::ECONNRESET: ...)` instead of `network timeout after retries`), since reporting a reset as a "timeout" is the misleading diagnostic the issue calls out; updated the 8 assertions pinning the old wording across `spec/soup/{bundler,importmap,npm,pip,spm,yarn}_parser_spec.rb`
- Rewrote the `TEST-06` block in `spec/soup/http_client_spec.rb`, which had asserted the defect as intended contract ("lets `Errno::ECONNREFUSED` bypass the retry loop and propagate") — it now drives retry/recovery coverage from `TRANSIENT_ERRORS` itself, so a class added without retry coverage fails the build
- Added `#registry_response` coverage in `spec/soup/base_parser_spec.rb`: warn-and-return-nil per transient class, the caller-supplied `outcome` text, non-2xx passthrough, and the headline regression — a parallel batch where one package resets must still collect the survivors
- Updated `docs/architecture.md`: documented `TRANSIENT_ERRORS`, corrected the retry algorithm and both risk-control rows, and removed the `safe_get` references left stale by #402

Explicitly out of scope: HTTP status codes are still returned to callers rather than retried (a 4xx/5xx is a response, not a transport failure), and SPM's rate-limit / bad-credentials aborts are unchanged because those are global conditions. The destructive partial save this issue names as an aggravating factor remains open as #373.

Fixes #375

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
