### PR TITLE
Fix #373: persist only verified packages when a run fails part-way

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,14 +111,15 @@
 - `PARSER_REGISTRY`: Private module-level constant (`module SOUP`) mapping lock file names to parser classes and skip flags
 - `DEPENDENCY_TEXT`: Private module-level constant (`module SOUP`) holding the value written into `requirements` and `verification_reasoning` for transitive dependencies
 - `initialize(argv)`: Configures options and initializes state
-- `execute`: Main entry point that runs the detection, checking, and output workflow. Uses an `ensure` block to persist partial state on failure
+- `execute`: Main entry point that runs the detection, checking, and output workflow. On success it calls `save_files` and marks the run complete; if it raises, the `ensure` block routes to `save_partial_state` instead, so a failed run can never take the full-overwrite path
 - `validate_config!`: Validates that configuration files exist and contain valid JSON
 - `detect_packages`: Scans for lock files and invokes appropriate parsers, then runs `parse_manual_entries` and `enforce_vendored_coverage`
 - `parse_manual_entries`: Invokes `ManualParser` on the manual entries file (default `config/soup-manual.json`) when it exists; parsed after auto-detected packages so a project can override an auto-detected entry by package name
 - `enforce_vendored_coverage`: Fails the run (sets the error exit code) when a committed file matched by `--vendored_globs` has no SOUP entry, matched on the entry's `file` path or basename
 - `read_cached_packages`: Loads previously entered user choices from cache
 - `check_packages`: Validates licenses, then for each package applies cached metadata, applies the transitive-dependency defaults (`apply_dependency_defaults` writes the lowest risk level and `DEPENDENCY_TEXT`), prompts for anything still missing, stamps `last_verified_at`, and appends the markdown row
-- `save_files`: Writes cache and markdown documentation files, returning early when nothing has been detected yet so an early failure (e.g. `validate_config!` raising) cannot overwrite an existing `.soup.json` with `{}`
+- `save_files`: The success path. Writes cache and markdown documentation files, replacing both wholesale — which is what lets a removed dependency drop out of the register. Only reached when every package completed `check_packages`
+- `save_partial_state`: The failure path. Persists only the packages that finished the whole `check_packages` iteration (`Package#verified?`), merged over the cache read at startup, so an interrupted run keeps the verification work it did complete without blanking the metadata of packages it never reached. Deliberately does not write the markdown register, because `@markdown` holds only the rows appended before the failure and a stale-but-complete table beats a truncated one
 
 **Internal Dependencies:**
 
@@ -568,7 +569,7 @@ Recoverable failures raise a subclass of `SOUP::Error` (`lib/soup/errors.rb`); t
 | Maven source unreachable | An unreachable `search.maven.org` query or POM mirror is skipped (warned) and the lookup falls through to the next source; the scan is not aborted | `lib/soup/parsers/gradle.rb` in `fetch_package`, via `BaseParser#registry_response` |
 | Missing package metadata | Logs warning and continues processing other packages | NPM, Gradle, SPM, Importmap parsers; `lookup_npm_registry_version` in `lib/soup/parsers/base.rb` |
 | Missing required IEC 62304 fields | Raises `MissingMetadataError` in `--no_prompt` mode, prompts user otherwise | `lib/soup/application.rb` in `prompt_missing_field` / `ensure_metadata_complete!` methods |
-| Partial execution failure | Persists partial state via `ensure` block so progress is not lost | `lib/soup/application.rb` in `execute` method |
+| Partial execution failure | Persists only fully verified packages via the `ensure` block, merged over the existing cache, so progress is not lost and previously recorded IEC 62304 evidence is never blanked; the published markdown register is left untouched rather than truncated | `lib/soup/application.rb` in `execute` / `save_partial_state` methods |
 | Unhandled exceptions | Displays error message and the top frames of the backtrace; full backtrace shown only when `ENV['DEBUG']` is set | `bin/soup.rb` top-level rescue |
 
 ### Security Controls

--- a/lib/soup/application.rb
+++ b/lib/soup/application.rb
@@ -48,6 +48,7 @@ module SOUP
       @detected_packages = {}
       @markdown = ''
       @exit_code = Status::SUCCESS_EXIT_CODE
+      @completed = false
     end
 
     def execute
@@ -56,9 +57,10 @@ module SOUP
       read_cached_packages
       check_packages
       save_files
+      @completed = true
       @exit_code
     ensure
-      save_files if @options&.soup_check
+      save_partial_state unless @completed
     end
 
     private
@@ -329,16 +331,51 @@ module SOUP
       Nokogiri::HTML.fragment(stripped).text
     end
 
+    # The success path: every package completed check_packages, so
+    # @detected_packages and @markdown are both authoritative and replace what
+    # was on disk -- which is what lets a removed dependency drop out of the
+    # register. Only reached when the whole run succeeded; a run that raised
+    # goes through save_partial_state instead.
     def save_files
       return unless @options.soup_check
-      # Guard against ensure-block invocations that fire before any work has been
-      # done (e.g. validate_config! raised). Without this, an early failure would
-      # overwrite the existing .soup.json with {} and the markdown file with ''.
       return if @detected_packages.empty? && @markdown.empty?
 
       File.write(@options.cache_file, JSON.pretty_generate(@detected_packages))
       FileUtils.mkdir_p(File.dirname(@options.markdown_file))
       File.write(@options.markdown_file, @markdown)
+    end
+
+    # The failure path (BUG-001). A run that raised part-way through
+    # check_packages leaves @detected_packages half-populated: every package
+    # after the failure point never reached apply_cached_metadata, so it still
+    # carries the empty verification fields Package#initialize gave it. The
+    # ensure block used to hand that straight to save_files, which
+    # * overwrote .soup.json with blank last_verified_at / risk_level /
+    #   requirements / verification_reasoning, destroying IEC 62304 evidence a
+    #   human had entered on a previous run, and
+    # * overwrote docs/soup.md with a header-only table, because @markdown only
+    #   ever received rows for the packages processed before the failure.
+    # One failed --no_prompt run in CI was therefore enough to wipe the
+    # register, recoverable only from git.
+    #
+    # The ensure-save exists for a real reason -- verification work already done
+    # this session should survive an interruption -- so the fix is to make the
+    # write additive rather than to drop it. Only packages that completed the
+    # full check_packages iteration are persisted (Package#verified? is exactly
+    # that test, since last_verified_at is stamped at the end of the loop body),
+    # layered over the cache that was read at startup. An entry can gain
+    # metadata this way; it can never lose any.
+    #
+    # The markdown is deliberately NOT written here. It is the published
+    # register: a stale-but-complete table beats a truncated one, and the next
+    # successful run regenerates it in full from every package.
+    def save_partial_state
+      return unless @options&.soup_check
+
+      verified = @detected_packages.select { |_name, package| package.verified? }
+      return if verified.empty?
+
+      File.write(@options.cache_file, JSON.pretty_generate(@cached_packages.merge(verified)))
     end
   end
 end

--- a/spec/soup/application_spec.rb
+++ b/spec/soup/application_spec.rb
@@ -462,36 +462,108 @@ RSpec.describe(SOUP::Application) do
       end
     end
 
+    # BUG-001: the ensure block handed the half-populated @detected_packages
+    # straight to save_files when a run raised part-way through check_packages.
+    # Every package after the failure point had never reached
+    # apply_cached_metadata, so it serialized with blank verification fields and
+    # overwrote the human-entered IEC 62304 evidence in .soup.json, while
+    # docs/soup.md was replaced by a header-only table. One failed --no_prompt
+    # run in CI destroyed the register.
+    #
+    # The ensure-save must still preserve work completed this session, so the
+    # write is now additive: only packages that finished the whole
+    # check_packages iteration are persisted, layered over the cache read at
+    # startup. The previous version of this context asserted merely that the
+    # cache was "not empty" after a failure -- which the destructive behaviour
+    # satisfied by writing blank entries, so it pinned the bug rather than the
+    # intent.
     context 'with partial state on failure' do
-      before do
-        two_pkg_lock = {
+      # Reproduces the issue's scenario exactly, with the failure in the middle
+      # so there is a package on each side of it. Hash order follows the
+      # lockfile:
+      #   aaa/transitive -- absent from require, so classified transitive and
+      #     completed by apply_dependency_defaults: real work done this run.
+      #   mmm/raises     -- direct, no cached metadata, so --no_prompt raises here.
+      #   zzz/cached     -- direct and previously verified, but never reached.
+      #     This is the package the old ensure-save destroyed.
+      def partial_failure_lock
+        {
           packages: [
-            {
-              name: 'first/pkg',
-              version: '1.0.0',
-              license: ['MIT'],
-              description: 'First',
-              homepage: 'https://example.com'
-            },
-            {
-              name: 'second/pkg',
-              version: '2.0.0',
-              license: ['MIT'],
-              description: 'Second',
-              homepage: 'https://example.com'
-            }
+            { name: 'aaa/transitive', version: '1.0.0', license: ['MIT'], description: 'T', homepage: '' },
+            { name: 'mmm/raises', version: '2.0.0', license: ['MIT'], description: 'R', homepage: '' },
+            { name: 'zzz/cached', version: '3.0.0', license: ['MIT'], description: 'C', homepage: '' }
           ],
           'packages-dev': []
         }.to_json
-        stub_composer_files(two_pkg_lock, '{"require":{"first/pkg":"^1.0","second/pkg":"^2.0"}}')
       end
 
-      it 'saves partial state when check_packages raises an exception', :aggregate_failures do
+      def direct_requires
+        '{"require":{"mmm/raises":"^2.0","zzz/cached":"^3.0"}}'
+      end
+
+      # Symbol keys serialize to the same JSON the real cache file holds; the
+      # assertions below read it back with string keys, as JSON.parse returns.
+      def previously_verified_cache
+        {
+          'zzz/cached': {
+            language: 'PHP',
+            package: 'zzz/cached',
+            version: '3.0.0',
+            license: 'MIT',
+            description: 'C',
+            website: '',
+            last_verified_at: '2025-01-01',
+            risk_level: 'High',
+            requirements: 'Critical subsystem',
+            verification_reasoning: 'Audited in 2025'
+          }
+        }
+      end
+
+      def run_expecting_failure
         app = described_class.new(soup_no_prompt_args(skip: skip_parsers_except_composer))
         expect { app.execute }
-          .to(raise_error(SOUP::MissingMetadataError, /No risk level found/))
-        cache_content = JSON.parse(File.read(cache_file.path))
-        expect(cache_content).not_to(be_empty)
+          .to(raise_error(SOUP::MissingMetadataError))
+        JSON.parse(File.read(cache_file.path))
+      end
+
+      before do
+        stub_composer_files(partial_failure_lock, direct_requires)
+        File.write(cache_file.path, JSON.generate(previously_verified_cache))
+      end
+
+      it 'still persists the packages this run finished verifying', :aggregate_failures do
+        cache_content = run_expecting_failure
+        expect(cache_content).to(have_key('aaa/transitive'))
+        expect(cache_content.dig('aaa/transitive', 'risk_level')).not_to(be_empty)
+      end
+
+      it 'does not blank a verified package that the run never reached', :aggregate_failures do
+        cache_content = run_expecting_failure
+        expect(cache_content.dig('zzz/cached', 'risk_level')).to(eq('High'))
+        expect(cache_content.dig('zzz/cached', 'requirements')).to(eq('Critical subsystem'))
+        expect(cache_content.dig('zzz/cached', 'verification_reasoning')).to(eq('Audited in 2025'))
+      end
+
+      it 'does not add the package that raised to the cache as a blank entry' do
+        expect(run_expecting_failure).not_to(have_key('mmm/raises'))
+      end
+
+      # The published register must not be truncated to the header-only table
+      # that @markdown holds when the run dies before appending every row.
+      it 'leaves the existing markdown register untouched' do
+        File.write(markdown_file, "# Software of Unknown Provenance\n\n| existing | row |\n")
+        run_expecting_failure
+        expect(File.read(markdown_file)).to(include('| existing | row |'))
+      end
+
+      # Nothing completed at all, so there is no work to preserve and the cache
+      # on disk must be left exactly as it was -- byte for byte.
+      it 'leaves the cache byte-identical when the run verified nothing' do
+        stub_composer_files(partial_failure_lock, '{"require":{"aaa/transitive":"^1.0","mmm/raises":"^2.0"}}')
+        before_bytes = File.read(cache_file.path)
+        run_expecting_failure
+        expect(File.read(cache_file.path)).to(eq(before_bytes))
       end
     end
 


### PR DESCRIPTION
## Summary

`Application#execute` ended in `ensure save_files if @options&.soup_check`. A run that raised part-way through `check_packages` left `@detected_packages` half-populated — every package after the failure point had never reached `apply_cached_metadata`, so it still carried the empty verification fields `Package#initialize` gave it — and the ensure block handed that straight to `save_files`, which overwrote `.soup.json` wholesale. `docs/soup.md` went the same way, replaced by the header-only table `@markdown` holds when the run dies before appending every row. One failed `--no_prompt` run in CI was enough to destroy the register, recoverable only from git.

Reproduced against `master` before fixing, with a pre-populated register and one new dependency:

```
raised: No risk level found for aaa/new!
cache keys after:      ["aaa/new", "zzz/old"]
zzz/old risk_level:    ""      <- was "High"
zzz/old requirements:  ""      <- was "Critical subsystem"
zzz/old reasoning:     ""      <- was "Audited 2025"
markdown: 0 data rows          <- register truncated to a bare header
```

The human-entered IEC 62304 evidence is blanked, not merely partially written.

The ensure-save exists for a real reason — verification work already done in a session should survive an interruption — so the fix makes the write additive rather than removing it. Success and failure no longer share a write path: `execute` marks the run complete after a clean `save_files`, and the `ensure` block routes to a new `save_partial_state` only when the run raised.

**Key changes:**

- `lib/soup/application.rb`: added `@completed`, set after a successful `save_files`, so the `ensure` block calls `save_partial_state` only on the failure path — a failed run can no longer take the full-overwrite path at all
- `save_partial_state` persists only packages that finished the entire `check_packages` iteration (`Package#verified?` is exactly that test, since `last_verified_at` is stamped at the end of the loop body), merged **over** the cache read at startup. An entry can gain metadata this way; it can never lose any
- `save_partial_state` deliberately does not write the markdown. It is the published register: a stale-but-complete table beats a truncated one, and the next successful run regenerates it in full
- `save_files` is unchanged in behaviour and now documents that it is the success path, whose wholesale replacement is what lets a removed dependency drop out of the register
- Replaced the `with partial state on failure` spec group in `spec/soup/application_spec.rb` with five examples covering both directions; 4 of them fail before this change
- Updated `docs/architecture.md` in three places: the `execute` description, the `save_files` / `save_partial_state` pair, and the "Partial execution failure" risk-control row

Note for reviewers: the previous spec, `saves partial state when check_packages raises an exception`, asserted only that the cache was **not empty** after a failure — which the destructive behaviour satisfied by writing blank entries. It pinned the bug rather than the intent, which is why this defect survived earlier work in this area. The replacement keeps one example (`still persists the packages this run finished verifying`) that passes both before and after on purpose, so the fix cannot regress into "just never write anything on failure".

Two of the three triggers this issue lists are already closed — the corrupt-cache path by #405 and the unrescued network errors by #408 — but the `--no_prompt` trigger was still live, and the ensure block remained destructive for any future exception raised from `check_packages`.

Fixes #373

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [x] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
