### PR TITLE
Correct parser External Dependencies in docs/architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,7 +278,7 @@
 **External Dependencies:**
 
 - `bundler`
-- `parallel`
+- `json`
 
 ### SOUP::ComposerParser
 
@@ -290,6 +290,10 @@
 
 - `parse(file, packages)`: Parses `packages` and `packages-dev` from the lock file and extracts metadata entirely from the lock file itself; one of the two parsers (with `ManualParser`) that makes no registry call, so it does not use `parallel_each`. Direct dependencies are the exact `require`/`require-dev` keys of the sibling `composer.json`
 - `extract_composer_license(raw)`: Normalizes the Composer `license` field, which the schema permits as either a single string or an array of SPDX strings
+
+**External Dependencies:**
+
+- `json`
 
 ### SOUP::GradleParser
 
@@ -309,8 +313,8 @@
 
 **External Dependencies:**
 
+- `net/http`
 - `nokogiri`
-- `parallel`
 
 ### SOUP::NPMParser
 
@@ -324,7 +328,7 @@
 
 **External Dependencies:**
 
-- `parallel`
+- None; the registry fetching and parallelization are inherited from `SOUP::BaseParser`
 
 ### SOUP::PIPParser
 
@@ -343,7 +347,7 @@
 
 **External Dependencies:**
 
-- `parallel`
+- `json`
 
 ### SOUP::SPMParser
 
@@ -363,7 +367,7 @@
 
 **External Dependencies:**
 
-- `parallel`
+- `json`
 
 ### SOUP::YarnParser
 
@@ -379,7 +383,7 @@
 
 **External Dependencies:**
 
-- `parallel`
+- `json`
 - `yarn_lock_parser`
 
 ### SOUP::ImportmapParser


### PR DESCRIPTION
# Summary

The per-parser **External Dependencies** sections in `docs/architecture.md` listed `parallel` for nearly every parser, but `parallel` is required only once — in `SOUP::BaseParser` (`lib/soup/parsers/base.rb`), which all parsers inherit from. The subclasses' own `require` lines were never reflected in the docs, so several real dependencies (`json`, `net/http`) were missing while a phantom one was repeated.

Each parser's list is now derived from its actual `require` statements in `lib/soup/parsers/`.

**Key changes:**

- `SOUP::BundlerParser`: `parallel` → `json` (keeps `bundler`)
- `SOUP::ComposerParser`: added a missing **External Dependencies** section listing `json`
- `SOUP::GradleParser`: `parallel` → `net/http` (keeps `nokogiri`)
- `SOUP::NPMParser`: `parallel` → a note that registry fetching and parallelization are inherited from `SOUP::BaseParser`
- `SOUP::PIPParser`, `SOUP::SPMParser`: `parallel` → `json`
- `SOUP::YarnParser`: `parallel` → `json` (keeps `yarn_lock_parser`)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change; no runtime code is affected. Each listed dependency was verified against the `require` lines in `lib/soup/parsers/`.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
