### PR TITLE
Bump rubocop to 1.89.0, drop obsolete cop disables, and fill doc gaps

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -350,7 +350,7 @@
   "rubocop": {
     "language": "Ruby",
     "package": "rubocop",
-    "version": "1.88.2",
+    "version": "1.89.0",
     "license": "MIT",
     "description": "RuboCop is a Ruby code style checking and code formatting tool.",
     "website": "https://rubocop.org/",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.88.2)
+    rubocop (1.89.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ JSON array of objects with at least a `package` key (plus optional `language`, `
 `website`, `file`, and the verification fields). When `--vendored_globs` is set, the run fails if any file matching those
 globs has no manual entry, so dropping a new vendored library into the repo cannot silently bypass the register.
 
-The soup file is generated in `./docs/soup.md` and a cache file `.soup.json` is used to preserved previously entered
+The soup file is generated in `./docs/soup.md` and a cache file `.soup.json` is used to preserve previously entered
 choices.
 
 ## Installation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,6 +234,10 @@
 
 - `parse(parser, file, packages)`: Validates arguments and delegates to specific parser
 
+**External Dependencies:**
+
+- None; the class only validates its arguments and delegates
+
 ### SOUP::BaseParser
 
 **Purpose:** Abstract base class providing the shared logic inherited by every language-specific parser: parallel metadata fetching, package construction, license normalization, and sibling-file resolution.
@@ -399,6 +403,10 @@
 - `PIN_REGEX`: Private constant matching `pin "name", to: "url"` directives
 - Reuses the npm helpers in `BaseParser` — `npm_registry_response`, `lookup_npm_registry_version`, and `build_npm_registry_package` — rather than holding its own registry URL. Every importmap pin is recorded as a direct dependency (`dependency: false`)
 
+**External Dependencies:**
+
+- None; the registry fetching and parallelization are inherited from `SOUP::BaseParser`
+
 ### SOUP::ManualParser
 
 **Purpose:** Reads manually-declared SOUP entries from a JSON file (default `config/soup-manual.json`) for vendored files and proprietary/commercial components that no package manager or registry can resolve.
@@ -411,6 +419,10 @@
 - Each entry supports `package` (required), plus optional `language`, `version`, `license`, `description`, `website`, and `file`; the `file` path lets the vendored-file coverage check (`Application#enforce_vendored_coverage`) match a committed file to its entry
 - Entries may pre-declare verification fields (`risk_level`, `requirements`, `verification_reasoning`); otherwise they fall back to the cache or prompt like any other package
 - `REQUIRED_KEY`: Private constant for the required `package` field
+
+**External Dependencies:**
+
+- None declared; `JSON` reaches this parser through the `SOUP::BaseParser` require chain, and the entries are read locally with no registry call
 
 ## Software of Unknown Provenance
 

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -31,7 +31,7 @@
 | Ruby | rspec-expectations | 3.13.5 | MIT | rspec-expectations provides a simple, readable API to express expected outcomes of a code example. | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rspec-mocks | 3.13.8 | MIT | RSpec's 'test double' framework, with support for stubbing and mocking | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rspec-support | 3.13.7 | MIT | Support utilities for RSpec gems | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | rubocop | 1.88.2 | MIT | RuboCop is a Ruby code style checking and code formatting tool. | <https://rubocop.org/> | 2026-05-22 | Low | Ruby linter | Most popular gem on rubygems |
+| Ruby | rubocop | 1.89.0 | MIT | RuboCop is a Ruby code style checking and code formatting tool. | <https://rubocop.org/> | 2026-05-22 | Low | Ruby linter | Most popular gem on rubygems |
 | Ruby | rubocop-ast | 1.50.0 | MIT | RuboCop's Node and NodePattern classes. | <https://www.rubocop.org/> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rubocop-capybara | 3.0.0 | MIT | Code style checking for Capybara test files (RSpec, Cucumber, Minitest). | <https://github.com/rubocop/rubocop-capybara> | 2026-05-22 | Low | Ruby linter | Most popular gem |
 | Ruby | rubocop-graphql | 1.7.0 | MIT | A collection of RuboCop cops to improve GraphQL-related code | <https://github.com/DmitryTsepelev/rubocop-graphql> | 2026-05-22 | Low | Ruby linter | Most popular gem |

--- a/spec/soup/npm_parser_spec.rb
+++ b/spec/soup/npm_parser_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe(SOUP::NPMParser) do
   let(:lock_file) do
     {
       packages: {
-        '': { version: '1.0.0' }, # rubocop:disable Naming/VariableNumber
+        '': { version: '1.0.0' },
         'node_modules/lodash': { version: '4.17.21' },
         'node_modules/dev-only': { version: '1.0.0', dev: true }
       }
@@ -181,7 +181,7 @@ RSpec.describe(SOUP::NPMParser) do
     let(:lock_file) do
       {
         packages: {
-          '': { version: '1.0.0' }, # rubocop:disable Naming/VariableNumber
+          '': { version: '1.0.0' },
           'node_modules/transitive-only': { version: '1.0.0' }
         }
       }.to_json
@@ -227,7 +227,7 @@ RSpec.describe(SOUP::NPMParser) do
   context 'with 100 packages (Parallel.map fan-out)' do
     let(:lock_file) do
       packages_hash =
-        (1..100).each_with_object({ '': { version: '1.0.0' } }) do |i, acc| # rubocop:disable Naming/VariableNumber
+        (1..100).each_with_object({ '': { version: '1.0.0' } }) do |i, acc|
           acc["node_modules/pkg-#{i}"] = { version: '1.0.0' }
         end
       { packages: packages_hash }.to_json
@@ -275,7 +275,7 @@ RSpec.describe(SOUP::NPMParser) do
       {
         lockfileVersion: 3,
         packages: {
-          '': { version: '1.0.0' }, # rubocop:disable Naming/VariableNumber
+          '': { version: '1.0.0' },
           'node_modules/lodash': { version: '4.17.21' }
         }
       }.to_json


### PR DESCRIPTION
# Summary

Routine dependency refresh for RuboCop, plus the small cleanups that fall out of it. RuboCop 1.89.0 no longer flags the empty-string hash key `''` used for the lockfile root entry under `Naming/VariableNumber`, so the four inline `rubocop:disable` comments in the npm parser spec are now redundant directives and become lint errors themselves. Removing them keeps the suite green on the new version.

Alongside the bump, three software units in `docs/architecture.md` were missing the **External Dependencies** subsection that every other unit in the document carries, and `README.md` had a grammar slip in the soup-file description.

**Key changes:**

- Bump `rubocop` from 1.88.2 to 1.89.0 in `Gemfile.lock`
- Remove four obsolete `# rubocop:disable Naming/VariableNumber` comments from `spec/soup/npm_parser_spec.rb`, now redundant under the new RuboCop version
- Add the missing **External Dependencies** sections to `SOUP::Parser`, `SOUP::ImportmapParser`, and `SOUP::ManualParser` in `docs/architecture.md`
- Fix "used to preserved" to "used to preserve" in `README.md`
- Regenerate `docs/soup.md` and `.soup.json` to reflect the new RuboCop version

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: No behaviour change — this is a dependency bump plus lint-directive and documentation cleanup, all covered by the existing suite
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
